### PR TITLE
Add regex option for stats tags

### DIFF
--- a/api/bootstrap.proto
+++ b/api/bootstrap.proto
@@ -109,6 +109,8 @@ message TagSpecifier {
   // source/common/config/well_known_names.h in the Envoy repository. If a
   // tag_name is provided in the config with an empty regex, Envoy will attempt
   // to find that name in its set of defaults and use the accompanying regex.
+  // Note: if any default tags are specified twice, the config will be
+  // considered invalid.
   string tag_name = 1;
 
   // The first capture group identifies the portion of the name to remove. The
@@ -129,6 +131,20 @@ message TagSpecifier {
   // Notice the regex will remove "foo_cluster.", but the tag value will be
   // "foo_cluster".
   string regex = 2;
+}
+
+message StatsConfig {
+  // Each stat name is iteratively processed through these tag specifiers.
+  // When a tag is matched, the capture group is removed from the name so later
+  // TagSpecifiers cannot match that same substring.
+  repeated TagSpecifier stats_tags = 1;
+
+  // Use all default tag regexes specified in Envoy. These can be combined with
+  // custom tags specified in stats_tags. They will be processed before the
+  // custom tags. Note: if any default tags are specified twice, the config will
+  // be considered invalid. See source/common/config/well_known_names.h for a
+  // a list of the default tags in Envoy.
+  bool use_all_default_tags = 2;
 }
 
 message Watchdog {
@@ -220,10 +236,8 @@ message Bootstrap {
   // Optional set of stats sinks.
   repeated StatsSink stats_sinks = 6;
 
-  // Each stat name is iteratively processed through these tag specifiers.
-  // When a tag is matched, the capture group is removed from the name so later
-  // TagSpecifiers cannot match that same substring.
-  repeated TagSpecifier stats_tags = 13;
+  // Configuration for internal processing of stats.
+  StatsConfig stats_config = 13;
 
   // Optional duration between flushes to configured stats sinks. For
   // performance reasons Envoy latches counters and only flushes counters and

--- a/api/bootstrap.proto
+++ b/api/bootstrap.proto
@@ -99,6 +99,38 @@ message StatsSink {
   google.protobuf.Struct config = 2;
 }
 
+// Designates a tag to strip from the tag extracted name and provide as a named
+// tag value for all statistics. This will only occur if a any part of the name
+// matches the regex provided with one or more capture groups.
+message TagSpecifier {
+  // Attaches an identifier to the tag values to identify the tag being in the
+  // sink. Envoy has a set of default names and regexes to extract dynamic
+  // portions of existing stats, which can be found in
+  // source/common/config/well_known_names.h in the Envoy repository. If a
+  // tag_name is provided in the config with an empty regex, Envoy will attempt
+  // to find that name in its set of defaults and use the accompanying regex.
+  string tag_name = 1;
+
+  // The first capture group identifies the portion of the name to remove. The
+  // second capture group (which will normally be nested inside the first)
+  // will designate the value of the tag for the statistic. If no second 
+  // capture group is provided, the first will also be used to set the value of
+  // the tag. All other capture groups will be ignored.
+  //
+  // For example:
+  //
+  // stat name: "cluster.foo_cluster.upstream_rq_timeout"
+  //
+  // tag name: "envoy.cluster_name" (one of many default stat regexes provided
+  // in Envoy)
+  //
+  // regex: "^cluster\.((.+?)\.)"
+  //
+  // Notice the regex will remove "foo_cluster.", but the tag value will be
+  // "foo_cluster".
+  string regex = 2;
+}
+
 message Watchdog {
   // The duration after which Envoy counts a nonresponsive thread in the
   // “server.watchdog_miss” statistic. If not specified the default is 200ms.
@@ -187,6 +219,11 @@ message Bootstrap {
 
   // Optional set of stats sinks.
   repeated StatsSink stats_sinks = 6;
+
+  // Each stat name is iteratively processed through these tag specifiers.
+  // When a tag is matched, the capture group is removed from the name so later
+  // TagSpecifiers cannot match that same substring.
+  repeated TagSpecifier stats_tags = 13;
 
   // Optional duration between flushes to configured stats sinks. For
   // performance reasons Envoy latches counters and only flushes counters and

--- a/api/bootstrap.proto
+++ b/api/bootstrap.proto
@@ -100,7 +100,7 @@ message StatsSink {
 }
 
 // Designates a tag to strip from the tag extracted name and provide as a named
-// tag value for all statistics. This will only occur if a any part of the name
+// tag value for all statistics. This will only occur if any part of the name
 // matches the regex provided with one or more capture groups.
 message TagSpecifier {
   // Attaches an identifier to the tag values to identify the tag being in the
@@ -128,23 +128,44 @@ message TagSpecifier {
   //
   // regex: "^cluster\.((.+?)\.)"
   //
-  // Notice the regex will remove "foo_cluster.", but the tag value will be
-  // "foo_cluster".
+  // Notice the regex will remove "foo_cluster." making the tag extracted name
+  // "cluster.upstream_rq_timeout" and the tag value for "envoy.cluster_name"
+  // "foo_cluster" (note: no '.' character because of the second capture group).
+  //
+  // An example with two regexes:
+  //
+  // First tag name: "envoy.http_user_agent"
+  // First regex: "^http(?=\\.).*?\\.user_agent\\.((.+?)\\.)\\w+?$"
+  // Second tag name: "envoy.http_conn_manager_prefix"
+  // Second regex: "^http\\.((.*?)\\.)"
+  // Stat name: "http.connection_manager_1.user_agent.ios.downstream_cx_total"
+  //
+  // The first regex will remove "ios." leaving the tag extracted name:
+  // "http.connection_manager_1.user_agent.downstream_cx_total".
+  // The tag "envoy.http_user_agent" will be added with tag value "ios".
+  //
+  // The second regex will remove "connection_manager_1." from the tag extracted
+  // name produced by the first regex
+  // ("http.connection_manager_1.user_agent.downstream_cx_total"), leaving
+  // "http.user_agent.downstream_cx_total" as the tag extracted name.  The tag
+  // "envoy.http_conn_manager_prefix" will be added with the tag value
+  // "connection_manager_1".
   string regex = 2;
 }
 
 message StatsConfig {
   // Each stat name is iteratively processed through these tag specifiers.
-  // When a tag is matched, the capture group is removed from the name so later
-  // TagSpecifiers cannot match that same substring.
+  // When a tag is matched, the first capture group is removed from the name so
+  // later TagSpecifiers cannot match that same portion of the match.
   repeated TagSpecifier stats_tags = 1;
 
   // Use all default tag regexes specified in Envoy. These can be combined with
   // custom tags specified in stats_tags. They will be processed before the
   // custom tags. Note: if any default tags are specified twice, the config will
   // be considered invalid. See source/common/config/well_known_names.h for a
-  // a list of the default tags in Envoy.
-  bool use_all_default_tags = 2;
+  // a list of the default tags in Envoy. If not provided, the value is assumed
+  // to be true.
+  google.protobuf.BoolValue use_all_default_tags = 2;
 }
 
 message Watchdog {

--- a/api/bootstrap.proto
+++ b/api/bootstrap.proto
@@ -136,9 +136,9 @@ message TagSpecifier {
   // An example with two regexes:
   //
   // First tag name: "envoy.http_user_agent"
-  // First regex: "^http(?=\\.).*?\\.user_agent\\.((.+?)\\.)\\w+?$"
+  // First regex: "^http(?=\.).*?\.user_agent\.((.+?)\.)\w+?$"
   // Second tag name: "envoy.http_conn_manager_prefix"
-  // Second regex: "^http\\.((.*?)\\.)"
+  // Second regex: "^http\.((.*?)\.)"
   // Stat name: "http.connection_manager_1.user_agent.ios.downstream_cx_total"
   //
   // The first regex will remove "ios." leaving the tag extracted name:

--- a/api/bootstrap.proto
+++ b/api/bootstrap.proto
@@ -14,6 +14,7 @@ import "api/lds.proto";
 
 import "google/protobuf/duration.proto";
 import "google/protobuf/struct.proto";
+import "google/protobuf/wrappers.proto";
 
 message LightstepConfig {
   // The cluster manager cluster that hosts the LightStep collectors.


### PR DESCRIPTION
Add regex expressions to extract tags from stats names.

There is going to be a relatively long list of default tags (coupled with regexes) in Envoy (maybe 22 or so).  I wanted to see what people think about adding an extra option to just use all the defaults rather than being forced to specify each one individually in the config.