### PR TITLE
bootstrap: specify optional EDS load stats endpoint in ClusterManager.

### DIFF
--- a/api/bootstrap.proto
+++ b/api/bootstrap.proto
@@ -74,6 +74,10 @@ message ClusterManager {
   // Optional configuration used to bind newly established upstream connections.
   // This may be overridden on a per-cluster basis by upstream_bind_config in the cds_config.
   BindConfig upstream_bind_config = 3;
+
+  // A management server endpoint to stream load stats to, as per
+  // StreamLoadStats in eds.proto. This must have api_type GRPC.
+  ApiConfigSource load_stats_config = 4;
 }
 
 // Stats proto for built-in "envoy.statsd" sink.


### PR DESCRIPTION
Signed-off-by: Harvey Tuch <htuch@google.com>