### PR TITLE
cds: rename field, update comments to match design choices

### DIFF
--- a/api/cds.proto
+++ b/api/cds.proto
@@ -259,19 +259,17 @@ message Cluster {
     // Specifications for subsets. For each entry, LbEndpoint.Metadata's
     // "envoy.lb" namespace is traversed and a subset is created for each unique
     // combination of key and value. For example:
-    // { "subset_keys": [
+    // { "subset_selectors": [
     //     { "keys": [ "version" ] },
     //     { "keys": [ "stage", "hardware_type" ] }
     // ]}
     // A subset is matched when the metadata from the selected route and
-    // weighted cluster contains the keys and values from the subset's
-    // metadata. Extra keys in the route metadata are ignored when comparing the
-    // subset's metadata. Subsets may overlap. In the case of overlapping
-    // subsets, the first matching subset is selected.
-    message LbSubsetKeys {
+    // weighted cluster contains the same keys and values as the subset's
+    // metadata. The same host may appear in multiple subsets.
+    message LbSubsetSelector {
       repeated string keys = 1;
     }
-    repeated LbSubsetKeys subset_keys = 3;
+    repeated LbSubsetSelector subset_selectors = 3;
   }
   LbSubsetConfig lb_subset_config = 22;
 }


### PR DESCRIPTION
Updates the comment to reflect the design decision made in envoyproxy/envoy#1735 and renames `subset_keys` to `subset_selectors`.

My reasoning for the rename is that the field is all about determining how endpoints are grouped into subsets. Using the names of metadata keys in the endpoints is only one way and others might be added.