### PR TITLE
cds: update cluster name restrictions in Cluster.

### DIFF
--- a/api/cds.proto
+++ b/api/cds.proto
@@ -64,6 +64,8 @@ message CircuitBreakers {
 message Cluster {
   // Supplies the name of the cluster which must be unique across all clusters.
   // Any : in the cluster name will be converted to _ when emitting statistics.
+  // TODO(htuch): cross-link to
+  // https://www.envoyproxy.io/envoy/operations/cli#cmdoption-max-obj-name-len.
   string name = 1;
 
   // The service discovery type to use for resolving the cluster.

--- a/api/cds.proto
+++ b/api/cds.proto
@@ -63,8 +63,7 @@ message CircuitBreakers {
 
 message Cluster {
   // Supplies the name of the cluster which must be unique across all clusters.
-  // The cluster name is used when emitting statistics. The cluster name can be
-  // at most 60 characters long, and must not contain :.
+  // Any : in the cluster name will be converted to _ when emitting statistics.
   string name = 1;
 
   // The service discovery type to use for resolving the cluster.


### PR DESCRIPTION
In response to https://github.com/envoyproxy/envoy/pull/1806 and
https://github.com/envoyproxy/envoy/pull/1871.

Signed-off-by: Harvey Tuch <htuch@google.com>