### PR TITLE
redirect: allow to specify redirect response code

### DIFF
--- a/api/rds.proto
+++ b/api/rds.proto
@@ -292,9 +292,9 @@ message RedirectAction {
 
   enum HTTPResponseCode {
     // Moved Permanently HTTP Status Code - 301.
-    MOVED_PERMANENTLY = 301;
+    MOVED_PERMANENTLY = 0;
     // Found HTTP Status Code - 302.
-    FOUND = 302;
+    FOUND = 1;
   }
   // The HTTP status code to use in the redirect response. The default response
   // code is MOVED_PERMANENTLY (301).

--- a/api/rds.proto
+++ b/api/rds.proto
@@ -290,15 +290,19 @@ message RedirectAction {
   // The path portion of the URL will be swapped with this value.
   string path_redirect = 2;
 
-  enum HTTPResponseCode {
+  enum RedirectResponseCode {
     // Moved Permanently HTTP Status Code - 301.
     MOVED_PERMANENTLY = 0;
     // Found HTTP Status Code - 302.
     FOUND = 1;
+    // See Other HTTP Status Code - 303.
+    SEE_OTHER = 2;
+    // Not Modified HTTP Status Code - 304.
+    NOT_MODIFIED = 3;
   }
   // The HTTP status code to use in the redirect response. The default response
   // code is MOVED_PERMANENTLY (301).
-  HTTPResponseCode response_code = 3;
+  RedirectResponseCode response_code = 3;
 }
 
 message Decorator {

--- a/api/rds.proto
+++ b/api/rds.proto
@@ -294,9 +294,9 @@ message RedirectAction {
   enum HTTPResponseCode {
     // Moved Permanently HTTP Status Code - 301. This is the default HTTP Status
     // code sent in redirect responses.
-    MOVED_PERMANENTLY = 0;
+    MOVED_PERMANENTLY = 301;
     // Found HTTP Status Code - 302.
-    FOUND = 1;
+    FOUND = 302;
   }
 }
 

--- a/api/rds.proto
+++ b/api/rds.proto
@@ -290,14 +290,15 @@ message RedirectAction {
   // The path portion of the URL will be swapped with this value.
   string path_redirect = 2;
 
-  // The HTTP status code to use in the redirect response.
   enum HTTPResponseCode {
-    // Moved Permanently HTTP Status Code - 301. This is the default HTTP Status
-    // code sent in redirect responses.
+    // Moved Permanently HTTP Status Code - 301.
     MOVED_PERMANENTLY = 301;
     // Found HTTP Status Code - 302.
     FOUND = 302;
   }
+  // The HTTP status code to use in the redirect response. The default response
+  // code is MOVED_PERMANENTLY (301).
+  HTTPResponseCode response_code = 3;
 }
 
 message Decorator {
@@ -468,9 +469,9 @@ message VirtualHost {
     // No TLS requirement for the virtual host.
     NONE = 0;
     // External requests must use TLS. If a request is external and it is not
-    // using TLS, a 302 redirect will be sent telling the client to use HTTPS.
+    // using TLS, a 301 redirect will be sent telling the client to use HTTPS.
     EXTERNAL_ONLY = 1;
-    // All requests must use TLS. If a request is not using TLS, a 302 redirect
+    // All requests must use TLS. If a request is not using TLS, a 301 redirect
     // will be sent telling the client to use HTTPS.
     ALL = 2;
   }

--- a/api/rds.proto
+++ b/api/rds.proto
@@ -285,12 +285,19 @@ message RouteAction {
 }
 
 message RedirectAction {
-  // A 302 redirect response will be sent which swaps the host portion of the
-  // URL with this value.
+  // The host portion of the URL will be swapped with this value.
   string host_redirect = 1;
-  // A 302 redirect response will be sent which swaps the path portion of the
-  // URL with this value.
+  // The path portion of the URL will be swapped with this value.
   string path_redirect = 2;
+
+  // The HTTP status code to use in the redirect response.
+  enum HTTPResponseCode {
+    // Moved Permanently HTTP Status Code - 301. This is the default HTTP Status
+    // code sent in redirect responses.
+    MOVED_PERMANENTLY = 0;
+    // Found HTTP Status Code - 302.
+    FOUND = 1;
+  }
 }
 
 message Decorator {


### PR DESCRIPTION
*Description*:
- Allow for redirect actions to specify which response code to use. Ex: some routes want to return a 302 instead of the default 301.
- Update documentation around TLS redirect response code to reflect code behavior.