### PR TITLE
add meaningful page titles

### DIFF
--- a/api/address.proto
+++ b/api/address.proto
@@ -4,6 +4,7 @@ package envoy.api.v2;
 
 import "google/protobuf/wrappers.proto";
 
+// protodoc-title: Network related configuration elements
 // [V2-API-DIFF] Addresses now have .proto structure.
 
 message Pipe {

--- a/api/base.proto
+++ b/api/base.proto
@@ -9,6 +9,8 @@ import "google/protobuf/duration.proto";
 import "google/protobuf/struct.proto";
 import "google/protobuf/wrappers.proto";
 
+// protodoc-title: Common configuration elements
+
 // Identifies location of where either Envoy runs or where upstream hosts run.
 message Locality {
   // Region this zone belongs to.

--- a/tools/protodoc/protodoc.py
+++ b/tools/protodoc/protodoc.py
@@ -138,7 +138,8 @@ def FormatHeader(style, text):
 def FormatHeaderFromFile(style, file_level_comment, alt):
   m = re.search('protodoc-title:\s([^\n]+)\n', file_level_comment)
   if m is not None:
-    return FormatHeader(style, str(m.group(1))), re.sub('protodoc-title\:[^\n]+\n\n', '', file_level_comment)
+    # remove title hint and any new lines that follow
+    return FormatHeader(style, str(m.group(1))), re.sub('protodoc-title\:[^\n]+\n\n?', '', file_level_comment)
   return FormatHeader(style, alt), file_level_comment
 
 def FormatFieldTypeAsJson(type_context, field):


### PR DESCRIPTION
Instead of having TOC elements like api/base.proto, we could add a title to protos with prefix
`protodoc-title: <title>`. These will be converted into page titles and stripped from the docs before rendering.

screen shots from words most popular browser
<img width="500" alt="screen shot 2017-10-30 at 10 12 37 pm" src="https://user-images.githubusercontent.com/8202871/32204590-9a9ea8fc-bdc0-11e7-9458-99ddcc422a01.png">
<img width="633" alt="screen shot 2017-10-30 at 10 18 51 pm" src="https://user-images.githubusercontent.com/8202871/32204592-9d276b86-bdc0-11e7-9366-7ff731821456.png">

Signed-off-by: Shriram Rajagopalan <shriram@us.ibm.com>