### PR TITLE
tcp route config

### DIFF
--- a/api/filter/network/BUILD
+++ b/api/filter/network/BUILD
@@ -53,7 +53,10 @@ api_proto_library(
 api_proto_library(
     name = "tcp_proxy",
     srcs = ["tcp_proxy.proto"],
-    deps = ["//api/filter:accesslog"],
+    deps = [
+        "//api/filter:accesslog",
+        "//api:address",
+    ],
 )
 
 api_proto_library(

--- a/api/filter/network/tcp_proxy.proto
+++ b/api/filter/network/tcp_proxy.proto
@@ -30,53 +30,59 @@ message TcpProxy {
   // Configuration for access logs.
   repeated AccessLog access_log = 5;
 
-  // A TCP proxy route consists of a set of optional L4 criteria and the
-  // name of a cluster. If a downstream connection matches all the
-  // specified criteria, the cluster in the route is used for the
-  // corresponding upstream connection. Routes are tried in the order
-  // specified until a match is found. If no match is found, the connection
-  // is closed. A route with no criteria is valid and always produces a
-  // match.
-  message TCPRoute {
-    // The cluster to connect to when a the downstream network connection
-    // matches the specified criteria.
-    string cluster = 1;
+  message DeprecatedV1 {
+    // [V2-API-DIFF] This is deprecated in v2. Routes will be matched using
+    // the FilterChainMatch in Listeners.
+    //
+    // A TCP proxy route consists of a set of optional L4 criteria and the
+    // name of a cluster. If a downstream connection matches all the
+    // specified criteria, the cluster in the route is used for the
+    // corresponding upstream connection. Routes are tried in the order
+    // specified until a match is found. If no match is found, the connection
+    // is closed. A route with no criteria is valid and always produces a
+    // match.
+    message TCPRoute {
+      // The cluster to connect to when a the downstream network connection
+      // matches the specified criteria.
+      string cluster = 1;
 
-    // An optional list of IP address subnets in the form
-    // “ip_address/xx”. The criteria is satisfied if the destination IP
-    // address of the downstream connection is contained in at least one of
-    // the specified subnets. If the parameter is not specified or the list
-    // is empty, the destination IP address is ignored. The destination IP
-    // address of the downstream connection might be different from the
-    // addresses on which the proxy is listening if the connection has been
-    // redirected.
-    repeated CidrRange destination_ip_list = 2;
+      // An optional list of IP address subnets in the form
+      // “ip_address/xx”. The criteria is satisfied if the destination IP
+      // address of the downstream connection is contained in at least one of
+      // the specified subnets. If the parameter is not specified or the list
+      // is empty, the destination IP address is ignored. The destination IP
+      // address of the downstream connection might be different from the
+      // addresses on which the proxy is listening if the connection has been
+      // redirected.
+      repeated CidrRange destination_ip_list = 2;
 
-    // An optional string containing a comma-separated list of port numbers
-    // or ranges. The criteria is satisfied if the destination port of the
-    // downstream connection is contained in at least one of the specified
-    // ranges. If the parameter is not specified, the destination port is
-    // ignored. The destination port address of the downstream connection
-    // might be different from the port on which the proxy is listening if
-    // the connection has been redirected.
-    string destination_ports = 3;
+      // An optional string containing a comma-separated list of port numbers
+      // or ranges. The criteria is satisfied if the destination port of the
+      // downstream connection is contained in at least one of the specified
+      // ranges. If the parameter is not specified, the destination port is
+      // ignored. The destination port address of the downstream connection
+      // might be different from the port on which the proxy is listening if
+      // the connection has been redirected.
+      string destination_ports = 3;
 
-    // An optional list of IP address subnets in the form
-    // “ip_address/xx”. The criteria is satisfied if the source IP address
-    // of the downstream connection is contained in at least one of the
-    // specified subnets. If the parameter is not specified or the list is
-    // empty, the source IP address is ignored.
-    repeated CidrRange source_ip_list = 4;
+      // An optional list of IP address subnets in the form
+      // “ip_address/xx”. The criteria is satisfied if the source IP address
+      // of the downstream connection is contained in at least one of the
+      // specified subnets. If the parameter is not specified or the list is
+      // empty, the source IP address is ignored.
+      repeated CidrRange source_ip_list = 4;
 
-    // An optional string containing a comma-separated list of port numbers
-    // or ranges. The criteria is satisfied if the source port of the
-    // downstream connection is contained in at least one of the specified
-    // ranges. If the parameter is not specified, the source port is
-    // ignored.
-    string source_ports = 5;
+      // An optional string containing a comma-separated list of port numbers
+      // or ranges. The criteria is satisfied if the source port of the
+      // downstream connection is contained in at least one of the specified
+      // ranges. If the parameter is not specified, the source port is
+      // ignored.
+      string source_ports = 5;
+    }
+
+    // The route table for the filter. All filter instances must have a route
+    // table, even if it is empty.
+    repeated TCPRoute routes = 1;
   }
-
-  // The route table for the filter. All filter instances must have a route
-  // table, even if it is empty.
-  repeated TCPRoute routes = 6;
+  DeprecatedV1 deprecated_v1 = 6;
 }

--- a/api/filter/network/tcp_proxy.proto
+++ b/api/filter/network/tcp_proxy.proto
@@ -7,7 +7,6 @@ import "api/filter/accesslog.proto";
 import "api/address.proto";
 
 import "google/protobuf/duration.proto";
-import "google/protobuf/wrappers.proto";
 
 // [V2-API-DIFF] The route match now takes place in the FilterChainMatch table.
 message TcpProxy {

--- a/api/filter/network/tcp_proxy.proto
+++ b/api/filter/network/tcp_proxy.proto
@@ -4,8 +4,10 @@ package envoy.api.v2.filter.network;
 option go_package = "network";
 
 import "api/filter/accesslog.proto";
+import "api/address.proto";
 
 import "google/protobuf/duration.proto";
+import "google/protobuf/wrappers.proto";
 
 // [V2-API-DIFF] The route match now takes place in the FilterChainMatch table.
 message TcpProxy {
@@ -28,4 +30,54 @@ message TcpProxy {
 
   // Configuration for access logs.
   repeated AccessLog access_log = 5;
+
+  // A TCP proxy route consists of a set of optional L4 criteria and the
+  // name of a cluster. If a downstream connection matches all the
+  // specified criteria, the cluster in the route is used for the
+  // corresponding upstream connection. Routes are tried in the order
+  // specified until a match is found. If no match is found, the connection
+  // is closed. A route with no criteria is valid and always produces a
+  // match.
+  message TCPRoute {
+    // The cluster to connect to when a the downstream network connection
+    // matches the specified criteria.
+    string cluster = 1;
+
+    // An optional list of IP address subnets in the form
+    // “ip_address/xx”. The criteria is satisfied if the destination IP
+    // address of the downstream connection is contained in at least one of
+    // the specified subnets. If the parameter is not specified or the list
+    // is empty, the destination IP address is ignored. The destination IP
+    // address of the downstream connection might be different from the
+    // addresses on which the proxy is listening if the connection has been
+    // redirected.
+    repeated CidrRange destination_ip_list = 2;
+
+    // An optional string containing a comma-separated list of port numbers
+    // or ranges. The criteria is satisfied if the destination port of the
+    // downstream connection is contained in at least one of the specified
+    // ranges. If the parameter is not specified, the destination port is
+    // ignored. The destination port address of the downstream connection
+    // might be different from the port on which the proxy is listening if
+    // the connection has been redirected.
+    string destination_ports = 3;
+
+    // An optional list of IP address subnets in the form
+    // “ip_address/xx”. The criteria is satisfied if the source IP address
+    // of the downstream connection is contained in at least one of the
+    // specified subnets. If the parameter is not specified or the list is
+    // empty, the source IP address is ignored.
+    repeated CidrRange source_ip_list = 4;
+
+    // An optional string containing a comma-separated list of port numbers
+    // or ranges. The criteria is satisfied if the source port of the
+    // downstream connection is contained in at least one of the specified
+    // ranges. If the parameter is not specified, the source port is
+    // ignored.
+    string source_ports = 5;
+  }
+
+  // The route table for the filter. All filter instances must have a route
+  // table, even if it is empty.
+  repeated TCPRoute routes = 6;
 }


### PR DESCRIPTION
Until the SNI feature arrives, we need this in order to have a usable V2 API plane. I have retained the configuration format as is (comma separated port list, etc.) so as to get a working implementation first.

Signed-off-by: Shriram Rajagopalan <shriram@us.ibm.com>