### PR TITLE
RDS: add response_headers_to_add/remove fields in VirtualHost and RouteAction

### DIFF
--- a/api/base.proto
+++ b/api/base.proto
@@ -116,7 +116,7 @@ message HeaderValueOption {
   // of -. [V2-API-DIFF].
   HeaderValue header = 1;
 
-  // Should the value be appended? If false (default), the value overrides
+  // Should the value be appended? If true (default), the value is appended to
   // existing values [V2-API-DIFF].
   google.protobuf.BoolValue append = 2;
 }

--- a/api/rds.proto
+++ b/api/rds.proto
@@ -198,8 +198,17 @@ message RouteAction {
   RoutingPriority priority = 11;
 
   // Specifies a set of headers that will be added to requests matching this
-  // route.
+  // route. In the presence of duplicate header keys, precedence rules apply.
   repeated HeaderValueOption request_headers_to_add = 12;
+
+  // Specifies a set of headers that will be added to responses to requests
+  // matching this route. In the presence of duplicate header keys, precedence
+  // rules apply.
+  repeated HeaderValueOption response_headers_to_add = 18;
+
+  // Specifies a list of HTTP headers that should be removed from each response
+  // to requests matching this route.
+  repeated string response_headers_to_remove = 19;
 
   // Specifies a set of rate limit configurations that could be applied to the
   // route.
@@ -501,6 +510,15 @@ message VirtualHost {
   // handled by this virtual host. In the presence of duplicate header keys,
   // precedence rules apply.
   repeated HeaderValueOption request_headers_to_add = 7;
+
+  // Specifies a list of HTTP headers that should be added to each response
+  // handled by this virtual host. In the presence of duplicate header keys,
+  // precedence rules apply.
+  repeated HeaderValueOption response_headers_to_add = 10;
+
+  // Specifies a list of HTTP headers that should be removed from each response
+  // handle by this virtual host.
+  repeated string response_headers_to_remove = 11;
 
   // Indicates that the virtual host has a CORS policy.
   CorsPolicy cors = 8;

--- a/api/rds.proto
+++ b/api/rds.proto
@@ -198,12 +198,13 @@ message RouteAction {
   RoutingPriority priority = 11;
 
   // Specifies a set of headers that will be added to requests matching this
-  // route. In the presence of duplicate header keys, precedence rules apply.
+  // route. Headers specified at this level are applied before headers from the
+  // enclosing VirtualHost and RouteConfiguration.
   repeated HeaderValueOption request_headers_to_add = 12;
 
   // Specifies a set of headers that will be added to responses to requests
-  // matching this route. In the presence of duplicate header keys, precedence
-  // rules apply.
+  // matching this route. Headers specified at this level are applied before
+  // headers from the enclosing VirtualHost and RouteConfiguration.
   repeated HeaderValueOption response_headers_to_add = 18;
 
   // Specifies a list of HTTP headers that should be removed from each response
@@ -507,13 +508,15 @@ message VirtualHost {
   repeated RateLimit rate_limits = 6;
 
   // Specifies a list of HTTP headers that should be added to each request
-  // handled by this virtual host. In the presence of duplicate header keys,
-  // precedence rules apply.
+  // handled by this virtual host. Headers specified at this level are applied
+  // after headers from enclosed RouteActions and before headers from the
+  // enclosing RouteConfiguration.
   repeated HeaderValueOption request_headers_to_add = 7;
 
   // Specifies a list of HTTP headers that should be added to each response
-  // handled by this virtual host. In the presence of duplicate header keys,
-  // precedence rules apply.
+  // handled by this virtual host. Headers specified at this level are applied
+  // after headers from enclosed RouteActions and before headers from the
+  // enclosing RouteConfiguration.
   repeated HeaderValueOption response_headers_to_add = 10;
 
   // Specifies a list of HTTP headers that should be removed from each response
@@ -544,7 +547,8 @@ message RouteConfiguration {
   repeated string internal_only_headers = 3;
 
   // Specifies a list of HTTP headers that should be added to each response that
-  // the connection manager encodes.
+  // the connection manager encodes. Headers specified at this level are applied
+  // after headers from any enclosed VirtualHost or RouteAction.
   repeated HeaderValueOption response_headers_to_add = 4;
 
   // Specifies a list of HTTP headers that should be removed from each response
@@ -552,8 +556,8 @@ message RouteConfiguration {
   repeated string response_headers_to_remove = 5;
 
   // Specifies a list of HTTP headers that should be added to each request
-  // routed by the HTTP connection manager. In the presence of duplicate
-  // header keys, precendence rules apply.
+  // routed by the HTTP connection manager. Headers specified at this level are
+  // applied after headers from any enclosed VirtualHost or RouteAction.
   repeated HeaderValueOption request_headers_to_add = 6;
 
   // An optional boolean that specifies whether the clusters that the route


### PR DESCRIPTION
Provides API support for envoyproxy/envoy#2002 and fixes comment related to envoyproxy/envoy#2003.