### PR TITLE
docs: change publish path

### DIFF
--- a/docs/publish.sh
+++ b/docs/publish.sh
@@ -4,7 +4,7 @@ set -e
 
 DOCS_DIR=generated/docs
 CHECKOUT_DIR=../envoy-docs
-PUBLISH_DIR="$CHECKOUT_DIR"/envoy-docs/latest
+PUBLISH_DIR="$CHECKOUT_DIR"/docs/envoy/latest
 BUILD_SHA=`git rev-parse HEAD`
 
 if [ -z "$CIRCLE_PULL_REQUEST" ] && [ "$CIRCLE_BRANCH" == "master" ]


### PR DESCRIPTION
I changed my mind. This will work better with other projects later.
I will clean up all the stale docs in the website repo once we are
fully converted to the new system.

Signed-off-by: Matt Klein <mklein@lyft.com>