### PR TITLE
fix typo in x-forwarded-client-cert description

### DIFF
--- a/docs/root/configuration/http_conn_man/headers.rst
+++ b/docs/root/configuration/http_conn_man/headers.rst
@@ -104,7 +104,7 @@ This is a convenience to avoid having to parse and understand XFF.
 x-forwarded-client-cert
 -----------------------
 
-*x-forwarded-clinet-cert* (XFCC) is a proxy header which indicates certificate information of part
+*x-forwarded-client-cert* (XFCC) is a proxy header which indicates certificate information of part
 or all of the clients or proxies that a request has flowed through, on its way from the client to the
 server. A proxy may choose to sanitize/append/forward the XFCC header before proxying the request.
 


### PR DESCRIPTION
Fix minor typo.