### PR TITLE
protodoc: some extra annotations.

### DIFF
--- a/api/address.proto
+++ b/api/address.proto
@@ -6,8 +6,8 @@ import "google/protobuf/wrappers.proto";
 
 import "validate/validate.proto";
 
-// protodoc-title: Network related configuration elements
-// [V2-API-DIFF] Addresses now have .proto structure.
+// [#protodoc-title: Network related configuration elements]
+// [#v2-api-diff: Addresses now have .proto structure.]
 
 message Pipe {
   string path = 1;
@@ -16,6 +16,7 @@ message Pipe {
 message SocketAddress {
   enum Protocol {
     TCP = 0;
+    // [#not-implemented-warn:]
     UDP = 1;
   }
   Protocol protocol = 1;

--- a/api/base.proto
+++ b/api/base.proto
@@ -9,7 +9,7 @@ import "google/protobuf/duration.proto";
 import "google/protobuf/struct.proto";
 import "google/protobuf/wrappers.proto";
 
-// protodoc-title: Common configuration elements
+// [#protodoc-title: Common configuration elements]
 
 // Identifies location of where either Envoy runs or where upstream hosts run.
 message Locality {


### PR DESCRIPTION
* [#not-implemented-hide:] will hide a message/enum/field from docs.
* [#not-implemented-warn:] will add a "Not implemented yet" warning to a
  message/enum/field.
* [#v2-api-diff:<text>] will add a note indicating v2 API difference to
  a message/enum/field.
* Switched title annotation to [#protodoc-title:<text>] for consistency.

Signed-off-by: Harvey Tuch <htuch@google.com>