### PR TITLE
Update protobuf dependency to 3.5.0.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -4,24 +4,18 @@ load("//bazel:repositories.bzl", "api_dependencies")
 
 api_dependencies()
 
-# TODO(htuch): This can switch back to a point release http_archive at the next
-# release (> 3.4.1), we need HEAD proto_library support and
-# https://github.com/google/protobuf/pull/3761.
 http_archive(
     name = "com_google_protobuf",
-    strip_prefix = "protobuf-c4f59dcc5c13debc572154c8f636b8a9361aacde",
-    sha256 = "5d4551193416861cb81c3bc0a428f22a6878148c57c31fb6f8f2aa4cf27ff635",
-    url = "https://github.com/google/protobuf/archive/c4f59dcc5c13debc572154c8f636b8a9361aacde.tar.gz",
+    sha256 = "0cc6607e2daa675101e9b7398a436f09167dffb8ca0489b0307ff7260498c13c",
+    strip_prefix = "protobuf-3.5.0",
+    urls = ["https://github.com/google/protobuf/archive/v3.5.0.tar.gz"],
 )
 
-# Needed for cc_proto_library, Bazel doesn't support aliases today for repos,
-# see https://groups.google.com/forum/#!topic/bazel-discuss/859ybHQZnuI and
-# https://github.com/bazelbuild/bazel/issues/3219.
 http_archive(
     name = "com_google_protobuf_cc",
-    strip_prefix = "protobuf-c4f59dcc5c13debc572154c8f636b8a9361aacde",
-    sha256 = "5d4551193416861cb81c3bc0a428f22a6878148c57c31fb6f8f2aa4cf27ff635",
-    url = "https://github.com/google/protobuf/archive/c4f59dcc5c13debc572154c8f636b8a9361aacde.tar.gz",
+    sha256 = "0cc6607e2daa675101e9b7398a436f09167dffb8ca0489b0307ff7260498c13c",
+    strip_prefix = "protobuf-3.5.0",
+    urls = ["https://github.com/google/protobuf/archive/v3.5.0.tar.gz"],
 )
 
 bind(


### PR DESCRIPTION
Matches https://github.com/envoyproxy/envoy/pull/2064

Signed-off-by: John Millikin <jmillikin@stripe.com>