### PR TITLE
docs: get HTTP connection manager building

### DIFF
--- a/api/BUILD
+++ b/api/BUILD
@@ -192,7 +192,10 @@ proto_library(
         ":cds",
         ":eds",
         ":lds",
+        ":protocol",
         ":rds",
+        "//api/filter:accesslog",
+        "//api/filter/http:http_connection_manager",
         "//api/filter/network:mongo_proxy",
     ],
 )

--- a/api/filter/accesslog.proto
+++ b/api/filter/accesslog.proto
@@ -248,11 +248,10 @@ message FileAccessLog {
   // [V2-API-DIFF] In addition to the existing format specifiers, the following
   // additional specifiers will be available:
   // %TLS_SNI_HOSTNAME%: SNI from handshake.
-  // %TLS_VERSION%: Possible values include: “TLSv1”, “TLSv1.1”,
-  //     “TLSv1.2”, “TLSv1.3”.
+  // %TLS_VERSION%: Possible values include: “TLSv1”, “TLSv1.1”, “TLSv1.2”, “TLSv1.3”.
   // %TLS_CIPHER_SUITE%: Cipher suite negotiated during the TLS handshake. The
-  //     value is four hex digits defined by the IANA TLS Cipher Suite Registry,
-  //     e.g. “009C” for TLS_RSA_WITH_AES_128_GCM_SHA256.
+  // value is four hex digits defined by the IANA TLS Cipher Suite Registry,
+  // e.g. “009C” for TLS_RSA_WITH_AES_128_GCM_SHA256.
   // TODO(htuch): Document how envoy.http_connection_manager.access_log values
   // can be accessed in the format specifier.
   string format = 2;

--- a/api/rds.proto
+++ b/api/rds.proto
@@ -346,6 +346,7 @@ message Route {
   // Decorator for matched route.
   Decorator decorator = 5;
 
+  // [#not-implemented-hide:]
   // Return a 401/403 when auth checks fail.
   // [V2-API-DIFF] new in v2.
   AuthAction auth = 6;
@@ -526,6 +527,7 @@ message VirtualHost {
   // Indicates that the virtual host has a CORS policy.
   CorsPolicy cors = 8;
 
+  // [#not-implemented-hide:]
   // Return a 401/403 when auth checks fail.
   // [V2-API-DIFF] new in v2.
   AuthAction auth = 9;

--- a/docs/build.sh
+++ b/docs/build.sh
@@ -28,8 +28,12 @@ bazel --batch build ${BAZEL_BUILD_OPTIONS} //api --aspects \
 PROTO_RST="
   /api/address/api/address.proto.rst
   /api/base/api/base.proto.rst
+  /api/filter/accesslog/api/filter/accesslog.proto.rst
   /api/filter/fault/api/filter/fault.proto.rst
+  /api/filter/http/http_connection_manager/api/filter/http/http_connection_manager.proto.rst
   /api/filter/network/mongo_proxy/api/filter/network/mongo_proxy.proto.rst
+  /api/protocol/api/protocol.proto.rst
+  /api/rds/api/rds.proto.rst
 "
 
 # Dump all the generated RST so they can be added to PROTO_RST easily.

--- a/docs/root/api-v2/filter/http/http.rst
+++ b/docs/root/api-v2/filter/http/http.rst
@@ -1,5 +1,5 @@
-Filters
-=======
+HTTP filters
+============
 
 .. CAUTION::
   This documentation subtree is a work-in-progress and does not yet contain
@@ -10,5 +10,3 @@ Filters
   :maxdepth: 2
 
   *
-  network/network
-  http/http


### PR DESCRIPTION
This PR just fixes enough stuff to get the HTTP connection manager filter
docs building. I want to get this out as it conflicts with other inflight
PRs and some of the work can be split up. E.g., access logging with that
in flight PR.

Signed-off-by: Matt Klein <mklein@lyft.com>