### PR TITLE
Replacing failover with priorities

### DIFF
--- a/api/eds.proto
+++ b/api/eds.proto
@@ -83,6 +83,16 @@ message LbEndpoint {
   // LocalityLbEndpoints. If unspecified, each host is presumed to have equal
   // weight in a locality.
   google.protobuf.UInt32Value load_balancing_weight = 4;
+
+  // Optional: the priority for this LbEndpoint
+  //
+  // Under usual circumstances, Envoy will only select endpoints for the highest
+  // priority (0).  In the event all endpoints for a particular priority are
+  // unavailable/unhealthy, Envoy will fail over to selecting endpoints for the
+  // next highest priority group.
+  //
+  // Priorities should range from 0 (highest) to N (lowest) without skipping.
+  google.protobuf.UInt32Value priority = 5;
 }
 
 // All endpoints belonging to a Locality.
@@ -186,10 +196,6 @@ message LoadStatsRequest {
 message ClusterLoadAssignment {
   string cluster_name = 1;
   repeated LocalityLbEndpoints endpoints = 2;
-  // In the case where all endpoints for a particular zone/subzone are
-  // unavailable/unhealthy, additional endpoints are given out for use in case
-  // of catastrophic failure. They also have weights.
-  repeated LocalityLbEndpoints failover_endpoints = 3;
   message Policy {
     // Percentage of traffic (0-100) that should be dropped. This
     // action allows protection of upstream hosts should they unable to

--- a/api/eds.proto
+++ b/api/eds.proto
@@ -84,7 +84,8 @@ message LbEndpoint {
   // weight in a locality.
   google.protobuf.UInt32Value load_balancing_weight = 4;
 
-  // Optional: the priority for this LbEndpoint
+  // Optional: the priority for this LbEndpoint.  If unspecified this will
+  // default to the highest priority (0).
   //
   // Under usual circumstances, Envoy will only select endpoints for the highest
   // priority (0).  In the event all endpoints for a particular priority are


### PR DESCRIPTION
As discussed and docced up here:
https://github.com/envoyproxy/envoy/pull/1980#issuecomment-341436710

My one remaining concern with this approach is that the clusters all take a cluster config on start-up so they won't all get the benefits of primary/failover mechanics.  It looks like static already doesn't get priorities so maybe it's meant to be a super simple start-up option but it seems like it still might benefit from the more advanced features. 

For  #1929