### PR TITLE
docs: add docs for prometheus stats

### DIFF
--- a/docs/root/operations/admin.rst
+++ b/docs/root/operations/admin.rst
@@ -141,3 +141,9 @@ The fields are:
   .. http:get:: /stats?format=json
 
   Outputs /stats in JSON format. This can be used for programmatic access of stats.
+
+  .. http:get:: /stats?format=prometheus
+
+  Outputs /stats in `Prometheus <https://prometheus.io/docs/instrumenting/exposition_formats/>`_
+  v0.0.4 format. This can be used to integrate with a Prometheus server. Currently, only counters and
+  gauges are outputed. Histograms will be outputed in a future update.


### PR DESCRIPTION
This PR is related to https://github.com/envoyproxy/envoy/pull/2026.

You also need `sphinx-rtd-theme` for the docs to build.