### PR TITLE
move accesslog.proto to dedicated namespace

### DIFF
--- a/api/BUILD
+++ b/api/BUILD
@@ -195,7 +195,7 @@ proto_library(
         ":lds",
         ":protocol",
         ":rds",
-        "//api/filter:accesslog",
+        "//api/filter/accesslog:accesslog",
         "//api/filter/network:http_connection_manager",
         "//api/filter/network:mongo_proxy",
     ],

--- a/api/filter/accesslog/BUILD
+++ b/api/filter/accesslog/BUILD
@@ -42,5 +42,8 @@ api_proto_library(
     name = "accesslog",
     srcs = ["accesslog.proto"],
     has_services = 1,
-    deps = ["//api:address", "//api:base"],
+    deps = [
+        "//api:address",
+        "//api:base"
+    ],
 )

--- a/api/filter/accesslog/BUILD
+++ b/api/filter/accesslog/BUILD
@@ -1,41 +1,46 @@
 load("//bazel:api_build_system.bzl", "api_proto_library")
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 
-licenses(["notice"])  # Apache 2
-
 # Go proto library dislikes proto libraries with no sources and only deps
 proto_library(
     name = "go_protos",
     srcs = [
-        "fault.proto",
+        "accesslog.proto",
     ],
     visibility = ["//visibility:public"],
     deps = [
         "//api:go_protos",
+        "@com_google_protobuf//:any_proto",
+        "@com_google_protobuf//:descriptor_proto",
         "@com_google_protobuf//:duration_proto",
         "@com_google_protobuf//:struct_proto",
         "@com_google_protobuf//:timestamp_proto",
         "@com_google_protobuf//:wrappers_proto",
         "@com_lyft_protoc_gen_validate//validate:validate_proto",
+        "@googleapis//:http_api_protos_lib",
     ],
 )
 
 go_proto_library(
     name = "go_default_library",
-    importpath = "api/filter",
+    importpath = "api/filter/accesslog",
     proto = ":go_protos",
     visibility = ["//visibility:public"],
     deps = [
         "//api:go_default_library",
+        "@com_github_golang_protobuf//ptypes/any:go_default_library",
         "@com_github_golang_protobuf//ptypes/duration:go_default_library",
         "@com_github_golang_protobuf//ptypes/struct:go_default_library",
         "@com_github_golang_protobuf//ptypes/timestamp:go_default_library",
         "@com_github_golang_protobuf//ptypes/wrappers:go_default_library",
+        "@org_golang_google_genproto//googleapis/api/annotations:go_default_library",
         "@com_lyft_protoc_gen_validate//validate:go_default_library",
     ],
 )
 
 api_proto_library(
-    name = "fault",
-    srcs = ["fault.proto"],
+    name = "accesslog",
+    srcs = ["accesslog.proto"],
+    has_services = 1,
+    deps = ["//api:address", "//api:base"],
 )

--- a/api/filter/accesslog/accesslog.proto
+++ b/api/filter/accesslog/accesslog.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package envoy.api.v2.filter;
+package envoy.api.v2.filter.accesslog;
 
 import "api/address.proto";
 import "api/base.proto";
@@ -12,7 +12,7 @@ import "google/protobuf/wrappers.proto";
 
 import "validate/validate.proto";
 
-
+// [#protodoc-title: Common access log types]
 // [#proto-status: draft]
 // Envoy access logs describe incoming interaction with Envoy over a fixed
 // period of time, and typically cover a single request/response exchange,
@@ -403,4 +403,3 @@ message AccessLog {
   // 2) "envoy.grpc_access_log": AccessLogServiceConfig
   google.protobuf.Struct config = 3;
 }
-

--- a/api/filter/http/BUILD
+++ b/api/filter/http/BUILD
@@ -20,6 +20,7 @@ proto_library(
     deps = [
         "//api:go_protos",
         "//api/filter:go_protos",
+        "//api/filter/accesslog:go_protos",
         "@com_google_protobuf//:any_proto",
         "@com_google_protobuf//:descriptor_proto",
         "@com_google_protobuf//:duration_proto",
@@ -39,6 +40,7 @@ go_proto_library(
     deps = [
         "//api:go_default_library",
         "//api/filter:go_default_library",
+        "//api/filter/accesslog:go_default_library",
         "@com_github_golang_protobuf//ptypes/any:go_default_library",
         "@com_github_golang_protobuf//ptypes/duration:go_default_library",
         "@com_github_golang_protobuf//ptypes/struct:go_default_library",
@@ -52,7 +54,7 @@ go_proto_library(
 api_proto_library(
     name = "router",
     srcs = ["router.proto"],
-    deps = ["//api/filter:accesslog"],
+    deps = ["//api/filter/accesslog:accesslog"],
 )
 
 api_proto_library(

--- a/api/filter/http/router.proto
+++ b/api/filter/http/router.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package envoy.api.v2.filter.http;
 
-import "api/filter/accesslog.proto";
+import "api/filter/accesslog/accesslog.proto";
 
 import "google/protobuf/wrappers.proto";
 
@@ -15,14 +15,16 @@ message Router {
   // Whether the router generates dynamic cluster statistics. Defaults to
   // true. Can be disabled in high performance scenarios.
   google.protobuf.BoolValue dynamic_stats = 1;
+
   // Whether to start a child span for egress routed calls. This can be
   // useful in scenarios where other filters (auth, ratelimit, etc.) make
   // outbound calls and have child spans rooted at the same ingress
   // parent. Defaults to false.
   bool start_child_span = 2;
+
   // Configuration for HTTP upstream logs emitted by the router. Upstream logs
   // are configured in the same way as access logs, but each log entry represents
   // an upstream request. Presuming retries are configured, multiple upstream
   // requests may be made for each downstream (inbound) request.
-  repeated AccessLog upstream_log = 3;
+  repeated accesslog.AccessLog upstream_log = 3;
 }

--- a/api/filter/network/BUILD
+++ b/api/filter/network/BUILD
@@ -18,6 +18,7 @@ proto_library(
     deps = [
         "//api:go_protos",
         "//api/filter:go_protos",
+        "//api/filter/accesslog:go_protos",
         "@com_google_protobuf//:any_proto",
         "@com_google_protobuf//:descriptor_proto",
         "@com_google_protobuf//:duration_proto",
@@ -37,6 +38,7 @@ go_proto_library(
     deps = [
         "//api:go_default_library",
         "//api/filter:go_default_library",
+        "//api/filter/accesslog:go_default_library",
         "@com_github_golang_protobuf//ptypes/any:go_default_library",
         "@com_github_golang_protobuf//ptypes/duration:go_default_library",
         "@com_github_golang_protobuf//ptypes/struct:go_default_library",
@@ -54,7 +56,7 @@ api_proto_library(
         "//api:base",
         "//api:protocol",
         "//api:rds",
-        "//api/filter:accesslog",
+        "//api/filter/accesslog:accesslog",
     ],
 )
 
@@ -68,7 +70,7 @@ api_proto_library(
     name = "tcp_proxy",
     srcs = ["tcp_proxy.proto"],
     deps = [
-        "//api/filter:accesslog",
+        "//api/filter/accesslog:accesslog",
         "//api:address",
     ],
 )

--- a/api/filter/network/http_connection_manager.proto
+++ b/api/filter/network/http_connection_manager.proto
@@ -6,7 +6,7 @@ option go_package = "network";
 import "api/base.proto";
 import "api/protocol.proto";
 import "api/rds.proto";
-import "api/filter/accesslog.proto";
+import "api/filter/accesslog/accesslog.proto";
 
 import "google/protobuf/duration.proto";
 import "google/protobuf/struct.proto";
@@ -162,7 +162,7 @@ message HttpConnectionManager {
 
   // Configuration for :ref:`HTTP access logs <arch_overview_access_logs>`
   // emitted by the connection manager.
-  repeated AccessLog access_log = 13;
+  repeated accesslog.AccessLog access_log = 13;
 
   // If set to true, the connection manager will use the real remote address
   // of the client connection when determining internal versus external origin and manipulating

--- a/api/filter/network/tcp_proxy.proto
+++ b/api/filter/network/tcp_proxy.proto
@@ -3,7 +3,7 @@ syntax = "proto3";
 package envoy.api.v2.filter.network;
 option go_package = "network";
 
-import "api/filter/accesslog.proto";
+import "api/filter/accesslog/accesslog.proto";
 import "api/address.proto";
 
 import "google/protobuf/duration.proto";
@@ -31,7 +31,7 @@ message TcpProxy {
   google.protobuf.Duration upstream_idle_timeout = 4;
 
   // Configuration for access logs.
-  repeated AccessLog access_log = 5;
+  repeated accesslog.AccessLog access_log = 5;
 
   message DeprecatedV1 {
     // [V2-API-DIFF] This is deprecated in v2. Routes will be matched using

--- a/docs/build.sh
+++ b/docs/build.sh
@@ -36,7 +36,7 @@ PROTO_RST="
   /api/lds/api/lds.proto.rst
   /api/rds/api/rds.proto.rst
   /api/sds/api/sds.proto.rst
-  /api/filter/accesslog/api/filter/accesslog.proto.rst
+  /api/filter/accesslog/accesslog/api/filter/accesslog/accesslog.proto.rst
   /api/filter/fault/api/filter/fault.proto.rst
   /api/filter/network/http_connection_manager/api/filter/network/http_connection_manager.proto.rst
   /api/filter/network/mongo_proxy/api/filter/network/mongo_proxy.proto.rst

--- a/docs/root/api-v2/filter/filter.rst
+++ b/docs/root/api-v2/filter/filter.rst
@@ -9,6 +9,7 @@ Filters
   :glob:
   :maxdepth: 2
 
-  *
   network/network
   http/http
+  accesslog/accesslog.proto
+  fault.proto

--- a/test/build/BUILD
+++ b/test/build/BUILD
@@ -6,7 +6,7 @@ api_cc_test(
     name = "build_test",
     srcs = ["build_test.cc"],
     proto_deps = [
-        "//api/filter:accesslog",
+        "//api/filter/accesslog:accesslog",
         "//api:cds",
         "//api:discovery",
         "//api:eds",

--- a/test/build/build_test.cc
+++ b/test/build/build_test.cc
@@ -6,7 +6,7 @@
 // Basic C++ build/link validation for the v2 xDS APIs.
 int main(int argc, char *argv[]) {
   const auto methods = {
-    "envoy.api.v2.filter.AccessLogService.StreamAccessLogs",
+    "envoy.api.v2.filter.accesslog.AccessLogService.StreamAccessLogs",
     "envoy.api.v2.AggregatedDiscoveryService.StreamAggregatedResources",
     "envoy.api.v2.ClusterDiscoveryService.FetchClusters",
     "envoy.api.v2.ClusterDiscoveryService.StreamClusters",


### PR DESCRIPTION
This avoids things like `filter.OrFilter` which makes no sense.

Signed-off-by: Matt Klein <mklein@lyft.com>