### PR TITLE
Remove rules_go

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1,3 +1,0 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_prefix")
-
-go_prefix("github.com/envoyproxy/data-plane-api")

--- a/api/BUILD
+++ b/api/BUILD
@@ -1,55 +1,6 @@
 load("//bazel:api_build_system.bzl", "api_proto_library")
-load("@io_bazel_rules_go//proto:def.bzl", "go_grpc_library")
 
 licenses(["notice"])  # Apache 2
-
-# Go proto library dislikes proto libraries with no sources and only deps
-proto_library(
-    name = "go_protos",
-    srcs = [
-        "address.proto",
-        "auth.proto",
-        "base.proto",
-        "bootstrap.proto",
-        "cds.proto",
-        "discovery.proto",
-        "eds.proto",
-        "hds.proto",
-        "health_check.proto",
-        "lds.proto",
-        "protocol.proto",
-        "rds.proto",
-        "rls.proto",
-        "sds.proto",
-    ],
-    visibility = ["//visibility:public"],
-    deps = [
-        "@com_google_protobuf//:any_proto",
-        "@com_google_protobuf//:descriptor_proto",
-        "@com_google_protobuf//:duration_proto",
-        "@com_google_protobuf//:struct_proto",
-        "@com_google_protobuf//:timestamp_proto",
-        "@com_google_protobuf//:wrappers_proto",
-        "@com_lyft_protoc_gen_validate//validate:validate_proto",
-        "@googleapis//:http_api_protos_lib",
-    ],
-)
-
-go_grpc_library(
-    name = "go_default_library",
-    importpath = "api",
-    proto = ":go_protos",
-    visibility = ["//visibility:public"],
-    deps = [
-        "@com_github_golang_protobuf//ptypes/any:go_default_library",
-        "@com_github_golang_protobuf//ptypes/duration:go_default_library",
-        "@com_github_golang_protobuf//ptypes/struct:go_default_library",
-        "@com_github_golang_protobuf//ptypes/timestamp:go_default_library",
-        "@com_github_golang_protobuf//ptypes/wrappers:go_default_library",
-        "@org_golang_google_genproto//googleapis/api/annotations:go_default_library",
-        "@com_lyft_protoc_gen_validate//validate:go_default_library",
-    ],
-)
 
 api_proto_library(
     name = "address",

--- a/api/filter/BUILD
+++ b/api/filter/BUILD
@@ -1,39 +1,6 @@
 load("//bazel:api_build_system.bzl", "api_proto_library")
-load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 
 licenses(["notice"])  # Apache 2
-
-# Go proto library dislikes proto libraries with no sources and only deps
-proto_library(
-    name = "go_protos",
-    srcs = [
-        "fault.proto",
-    ],
-    visibility = ["//visibility:public"],
-    deps = [
-        "//api:go_protos",
-        "@com_google_protobuf//:duration_proto",
-        "@com_google_protobuf//:struct_proto",
-        "@com_google_protobuf//:timestamp_proto",
-        "@com_google_protobuf//:wrappers_proto",
-        "@com_lyft_protoc_gen_validate//validate:validate_proto",
-    ],
-)
-
-go_proto_library(
-    name = "go_default_library",
-    importpath = "api/filter",
-    proto = ":go_protos",
-    visibility = ["//visibility:public"],
-    deps = [
-        "//api:go_default_library",
-        "@com_github_golang_protobuf//ptypes/duration:go_default_library",
-        "@com_github_golang_protobuf//ptypes/struct:go_default_library",
-        "@com_github_golang_protobuf//ptypes/timestamp:go_default_library",
-        "@com_github_golang_protobuf//ptypes/wrappers:go_default_library",
-        "@com_lyft_protoc_gen_validate//validate:go_default_library",
-    ],
-)
 
 api_proto_library(
     name = "fault",

--- a/api/filter/accesslog/BUILD
+++ b/api/filter/accesslog/BUILD
@@ -1,42 +1,4 @@
 load("//bazel:api_build_system.bzl", "api_proto_library")
-load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
-
-# Go proto library dislikes proto libraries with no sources and only deps
-proto_library(
-    name = "go_protos",
-    srcs = [
-        "accesslog.proto",
-    ],
-    visibility = ["//visibility:public"],
-    deps = [
-        "//api:go_protos",
-        "@com_google_protobuf//:any_proto",
-        "@com_google_protobuf//:descriptor_proto",
-        "@com_google_protobuf//:duration_proto",
-        "@com_google_protobuf//:struct_proto",
-        "@com_google_protobuf//:timestamp_proto",
-        "@com_google_protobuf//:wrappers_proto",
-        "@com_lyft_protoc_gen_validate//validate:validate_proto",
-        "@googleapis//:http_api_protos_lib",
-    ],
-)
-
-go_proto_library(
-    name = "go_default_library",
-    importpath = "api/filter/accesslog",
-    proto = ":go_protos",
-    visibility = ["//visibility:public"],
-    deps = [
-        "//api:go_default_library",
-        "@com_github_golang_protobuf//ptypes/any:go_default_library",
-        "@com_github_golang_protobuf//ptypes/duration:go_default_library",
-        "@com_github_golang_protobuf//ptypes/struct:go_default_library",
-        "@com_github_golang_protobuf//ptypes/timestamp:go_default_library",
-        "@com_github_golang_protobuf//ptypes/wrappers:go_default_library",
-        "@org_golang_google_genproto//googleapis/api/annotations:go_default_library",
-        "@com_lyft_protoc_gen_validate//validate:go_default_library",
-    ],
-)
 
 api_proto_library(
     name = "accesslog",

--- a/api/filter/http/BUILD
+++ b/api/filter/http/BUILD
@@ -1,55 +1,6 @@
 load("//bazel:api_build_system.bzl", "api_proto_library")
-load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 
 licenses(["notice"])  # Apache 2
-
-# Go proto library dislikes proto libraries with no sources and only deps
-proto_library(
-    name = "go_protos",
-    srcs = [
-        "buffer.proto",
-        "fault.proto",
-        "health_check.proto",
-        "ip_tagging.proto",
-        "lua.proto",
-        "rate_limit.proto",
-        "router.proto",
-        "transcoder.proto",
-    ],
-    visibility = ["//visibility:public"],
-    deps = [
-        "//api:go_protos",
-        "//api/filter:go_protos",
-        "//api/filter/accesslog:go_protos",
-        "@com_google_protobuf//:any_proto",
-        "@com_google_protobuf//:descriptor_proto",
-        "@com_google_protobuf//:duration_proto",
-        "@com_google_protobuf//:struct_proto",
-        "@com_google_protobuf//:timestamp_proto",
-        "@com_google_protobuf//:wrappers_proto",
-        "@com_lyft_protoc_gen_validate//validate:validate_proto",
-        "@googleapis//:http_api_protos_lib",
-    ],
-)
-
-go_proto_library(
-    name = "go_default_library",
-    importpath = "api/filter/http",
-    proto = ":go_protos",
-    visibility = ["//visibility:public"],
-    deps = [
-        "//api:go_default_library",
-        "//api/filter:go_default_library",
-        "//api/filter/accesslog:go_default_library",
-        "@com_github_golang_protobuf//ptypes/any:go_default_library",
-        "@com_github_golang_protobuf//ptypes/duration:go_default_library",
-        "@com_github_golang_protobuf//ptypes/struct:go_default_library",
-        "@com_github_golang_protobuf//ptypes/timestamp:go_default_library",
-        "@com_github_golang_protobuf//ptypes/wrappers:go_default_library",
-        "@org_golang_google_genproto//googleapis/api/annotations:go_default_library",
-        "@com_lyft_protoc_gen_validate//validate:go_default_library",
-    ],
-)
 
 api_proto_library(
     name = "router",

--- a/api/filter/network/BUILD
+++ b/api/filter/network/BUILD
@@ -1,53 +1,6 @@
 load("//bazel:api_build_system.bzl", "api_proto_library")
-load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 
 licenses(["notice"])  # Apache 2
-
-# Go proto library dislikes proto libraries with no sources and only deps
-proto_library(
-    name = "go_protos",
-    srcs = [
-        "client_ssl_auth.proto",
-        "http_connection_manager.proto",
-        "mongo_proxy.proto",
-        "rate_limit.proto",
-        "redis_proxy.proto",
-        "tcp_proxy.proto",
-    ],
-    visibility = ["//visibility:public"],
-    deps = [
-        "//api:go_protos",
-        "//api/filter:go_protos",
-        "//api/filter/accesslog:go_protos",
-        "@com_google_protobuf//:any_proto",
-        "@com_google_protobuf//:descriptor_proto",
-        "@com_google_protobuf//:duration_proto",
-        "@com_google_protobuf//:struct_proto",
-        "@com_google_protobuf//:timestamp_proto",
-        "@com_google_protobuf//:wrappers_proto",
-        "@com_lyft_protoc_gen_validate//validate:validate_proto",
-        "@googleapis//:http_api_protos_lib",
-    ],
-)
-
-go_proto_library(
-    name = "go_default_library",
-    importpath = "api/filter/network",
-    proto = ":go_protos",
-    visibility = ["//visibility:public"],
-    deps = [
-        "//api:go_default_library",
-        "//api/filter:go_default_library",
-        "//api/filter/accesslog:go_default_library",
-        "@com_github_golang_protobuf//ptypes/any:go_default_library",
-        "@com_github_golang_protobuf//ptypes/duration:go_default_library",
-        "@com_github_golang_protobuf//ptypes/struct:go_default_library",
-        "@com_github_golang_protobuf//ptypes/timestamp:go_default_library",
-        "@com_github_golang_protobuf//ptypes/wrappers:go_default_library",
-        "@org_golang_google_genproto//googleapis/api/annotations:go_default_library",
-        "@com_lyft_protoc_gen_validate//validate:go_default_library",
-    ],
-)
 
 api_proto_library(
     name = "http_connection_manager",


### PR DESCRIPTION
Gogoproto is not supported natively by bazel, and requires extra hackery that is best kept hidden in the consumer of the repo.

Note that rules_go are still imported as protoc-gen-validate does not build without them.

Signed-off-by: Kuat Yessenov <kuat@google.com>