### PR TITLE
Add metadata field to Cluster in CDS

### DIFF
--- a/api/cds.proto
+++ b/api/cds.proto
@@ -320,11 +320,11 @@ message Cluster {
   // See base.TransportSocket description.
   TransportSocket transport_socket = 24;
 
-  // The Metadata field can be used to provide additional information
-  // about the cluster. It can be used for stats, logging, and varying filter
-  // behavior. Fields should use namespace notation to denote which entity
-  // within Envoy will need the information. For instance, if the metadata
-  // is intended for the Router filter, the filter name should be specified as
-  // *envoy.router*.
+  // [#not-implemented-hide:] The Metadata field can be used to provide
+  // additional information about the cluster. It can be used for stats,
+  // logging, and varying filter behavior. Fields should use reverse DNS
+  // notation to denote which entity within Envoy will need the information.
+  // For instance, if the metadata is intended for the Router filter, the filter
+  // name should be specified as *envoy.router*.
   Metadata metadata = 25;
 }

--- a/api/cds.proto
+++ b/api/cds.proto
@@ -319,4 +319,12 @@ message Cluster {
 
   // See base.TransportSocket description.
   TransportSocket transport_socket = 24;
+
+  // The Metadata field can be used to provide additional information
+  // about the cluster. It can be used for stats, logging, and varying filter
+  // behavior. Fields should use namespace notation to denote which entity
+  // within Envoy will need the information. For instance, if the metadata
+  // is intended for the Router filter, the filter name should be specified as
+  // *envoy.router*.
+  Metadata metadata = 25;
 }


### PR DESCRIPTION
Rather than opening an issue, I figured it would just make sense to discuss this in this PR as it's a relatively small addition.  

We'd like to add a metadata field to CDS and have it be accessible in Envoy through [ClusterInfo](https://github.com/envoyproxy/envoy/blob/master/include/envoy/upstream/upstream.h#L275) and anywhere else general cluster info is available.  