### PR TITLE
Zipkin Dashboard URL link should use docker-machine ip.

### DIFF
--- a/docs/root/install/sandboxes/zipkin_tracing.rst
+++ b/docs/root/install/sandboxes/zipkin_tracing.rst
@@ -75,7 +75,8 @@ You can now send a request to service1 via the front-envoy as follows::
 
 **Step 3: View the traces in Zipkin UI**
 
-Point your browser to http://localhost:9411 . You should see the Zipkin dashboard.
+Obtain docker machine ip address by running $ docker-machine ip default and connecting to port 9411.
+Most likely this will be: http://192.168.99.100:9411. You should now see the Zipkin dashboard. 
 Set the service to "front-proxy" and set the start time to a few minutes before
 the start of the test (step 2) and hit enter. You should see traces from the front-proxy.
 Click on a trace to explore the path taken by the request from front-proxy to service1


### PR DESCRIPTION
Signed-off-by: Daljeet Virdi daljeetv@gmail.com

Description: The link to Zipkin dashboard was incorrect.

Risk Level: Low

Testing: tested locally.