### PR TITLE
External auth filter2

### DIFF
--- a/api/BUILD
+++ b/api/BUILD
@@ -9,7 +9,10 @@ api_proto_library(
 
 api_proto_library(
     name = "auth",
-    srcs = ["auth.proto", "external_auth.proto"],
+    srcs = [
+        "auth.proto",
+        "external_auth.proto",
+    ],
     deps = [":sds"],
 )
 

--- a/api/BUILD
+++ b/api/BUILD
@@ -9,7 +9,7 @@ api_proto_library(
 
 api_proto_library(
     name = "auth",
-    srcs = ["auth.proto"],
+    srcs = ["auth.proto", "external_auth.proto"],
     deps = [":sds"],
 )
 

--- a/api/BUILD
+++ b/api/BUILD
@@ -13,7 +13,10 @@ api_proto_library(
         "auth.proto",
         "external_auth.proto",
     ],
-    deps = [":sds"],
+    deps = [
+        ":sds",
+        ":address",
+    ],
 )
 
 api_proto_library(

--- a/api/BUILD
+++ b/api/BUILD
@@ -8,18 +8,6 @@ api_proto_library(
 )
 
 api_proto_library(
-    name = "auth",
-    srcs = [
-        "auth.proto",
-        "external_auth.proto",
-    ],
-    deps = [
-        ":sds",
-        ":address",
-    ],
-)
-
-api_proto_library(
     name = "base",
     srcs = ["base.proto"],
     deps = [":address"],
@@ -126,9 +114,9 @@ api_proto_library(
     srcs = ["rds.proto"],
     has_services = 1,
     deps = [
-        ":auth",
         ":base",
         ":discovery",
+        "//api/auth",
     ],
 )
 

--- a/api/auth/BUILD
+++ b/api/auth/BUILD
@@ -1,0 +1,15 @@
+load("//bazel:api_build_system.bzl", "api_proto_library")
+
+licenses(["notice"])  # Apache 2
+
+api_proto_library(
+    name = "auth",
+    srcs = [
+        "auth.proto",
+        "external_auth.proto",
+    ],
+    deps = [
+        "//api:address",
+        "//api:sds",
+    ],
+)

--- a/api/auth/auth.proto
+++ b/api/auth/auth.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 // [#proto-status: draft]
 
-package envoy.api.v2;
+package envoy.api.v2.auth;
 
 import "api/sds.proto";
 

--- a/api/auth/external_auth.proto
+++ b/api/auth/external_auth.proto
@@ -62,9 +62,6 @@ message AttributeContext {
     // SPIFFE format is `spiffe://trust-domain/path`
     // Google account format is `https://accounts.google.com/{userid}`
     string principal = 4;
-
-    // Other claims about the peer that are not captured in labels and principal.
-    google.protobuf.Struct claims = 5;
   }
 
   // Represents a network request, such as an HTTP request.
@@ -72,8 +69,7 @@ message AttributeContext {
     oneof request {
       HTTPRequest http_request = 1;
     }
-    // The timestamp when the `destination` service receives the first byte of
-    // the request.
+    // The timestamp when the proxy receives the first byte of the request.
     google.protobuf.Timestamp time = 2;
   }
 
@@ -145,6 +141,7 @@ message AttributeContext {
 // Origin peer that originated the request
 // Caching Protocol
 // request_context return values to inject back into the filter chain
+// peer.claims -- from X.509 extensions
 // Configuration
 // - field mask to send
 // - which return values from request_context are copied back

--- a/api/auth/external_auth.proto
+++ b/api/auth/external_auth.proto
@@ -56,7 +56,6 @@ message AttributeContext {
     // For example, the identity associated with the workload such as a service account.
     // If an X.509 certificate is used to assert the identity this field should be sourced from
     // `Subject` or `Subject Alternative Names`. The primary identity should be the principal.
-    // Aliases should be placed claims.
     // The principal format is issuer specific.
     // For example
     // SPIFFE format is `spiffe://trust-domain/path`

--- a/api/auth/external_auth.proto
+++ b/api/auth/external_auth.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 // [#proto-status: draft]
 
-package envoy.api.v2;
+package envoy.api.v2.auth;
 
 import "api/address.proto";
 import "google/protobuf/struct.proto";

--- a/api/external_auth.proto
+++ b/api/external_auth.proto
@@ -9,21 +9,18 @@ import "google/protobuf/timestamp.proto";
 import "google/rpc/status.proto";
 
 // Authorization service.
-// Primarily responds with OK or NOT OK.
+// Primarily responds with `OK` or `NOT OK`.
 service Authorization {
   rpc Check(CheckRequest) returns (CheckResponse);
 }
 
 message CheckRequest {
-  // The name of the tenant for multi-tenant support.
-  string tenant_name = 1;
-
   // The request attributes.
-  AttributeContext attributes = 2;
+  AttributeContext attributes = 1;
 }
 
 message CheckResponse {
-  // Status OK allows the request. Any other response indicates the request should be denied.
+  // Status `OK` allows the request. Any other status indicates the request should be denied.
   google.rpc.Status status = 1;
 }
 
@@ -31,10 +28,7 @@ message CheckResponse {
 // For example, the size of an HTTP request, or the status code of an HTTP response.
 //
 // Each attribute has a type and a name, which is logically defined as a proto message field.
-// The fields follow the Istio attribute vocabulary.
-// https://istio.io/docs/reference/config/mixer/attribute-vocabulary.html
-// The field type becomes the attribute type, and the field path becomes the attribute name.
-// For example, the attribute `source.ip` maps to field `AttributeContext.source.ip`.
+// AttributeContext is a collection of individual attributes.
 message AttributeContext {
   // This message defines attributes for a node that handles a network request.
   // The node can be either a service or an application that sends, forwards,
@@ -48,6 +42,8 @@ message AttributeContext {
     int64 port = 2;
 
     // The canonical service name of the peer.
+    // It should be set to `x-envoy-downstream-service-cluster <https://www.envoyproxy.io/docs/envoy/latest/configuration/http_conn_man/headers#x-envoy-downstream-service-cluster>`
+    // If a more trusted source of the service name is available through mTLS/secure naming, it should be used.
     string service = 3;
 
     // The labels associated with the peer.
@@ -55,19 +51,19 @@ message AttributeContext {
     // The source of the labels could be an X.509 certificate or other configuration.
     map<string, string> labels = 4;
 
-    // The validated identity of this peer.
+    // The authenticated identity of this peer.
     // For example, the identity associated with the workload such as a service account.
     // If an X.509 certificate is used to assert the identity this field should be sourced from
-    // `Subject` and `Subject Alternative Names`.
-    repeated string principals = 5;
+    // `Subject` or `Subject Alternative Names`. The primary identity should be the principal.
+    // Aliases should be placed claims.
+    // The principal format is issuer specific.
+    // For example
+    // SPIFFE format is `spiffe://trust-domain/path`
+    // Google account format is `https://accounts.google.com/{userid}`
+    string principal = 5;
 
-    // Other claims about the peer that are not captured in labels and principals.
+    // Other claims about the peer that are not captured in labels and principal.
     google.protobuf.Struct claims = 6;
-
-    // The CLDR country/region code associated with the above IP address.
-    // If the IP address is private, the `region_code` should reflect the
-    // physical location where this peer is running.
-    string region_code = 7;
   }
 
   // This message defines attributes for an HTTP request. If the actual
@@ -114,7 +110,7 @@ message AttributeContext {
 
     // The network protocol used with the request, such as "http/1.1",
     // "spdy/3", "h2", "h2c", "webrtc", "tcp", "udp", "quic". See
-    // https://www.iana.org/assignments/tls-extensiontype-values/tls-extensiontype-values.xhtml#alpn-protocol-ids
+    // `protocol ids <https://www.iana.org/assignments/tls-extensiontype-values/tls-extensiontype-values.xhtml#alpn-protocol-ids>`
     // for details.
     string protocol = 11;
   }

--- a/api/external_auth.proto
+++ b/api/external_auth.proto
@@ -42,7 +42,7 @@ message AttributeContext {
     int64 port = 2;
 
     // The canonical service name of the peer.
-    // It should be set to `x-envoy-downstream-service-cluster <https://www.envoyproxy.io/docs/envoy/latest/configuration/http_conn_man/headers#x-envoy-downstream-service-cluster>`
+    // It should be set to :ref:`x-envoy-downstream-service-cluster <https://www.envoyproxy.io/docs/envoy/latest/configuration/http_conn_man/headers#x-envoy-downstream-service-cluster>`
     // If a more trusted source of the service name is available through mTLS/secure naming, it should be used.
     string service = 3;
 
@@ -110,7 +110,7 @@ message AttributeContext {
 
     // The network protocol used with the request, such as "http/1.1",
     // "spdy/3", "h2", "h2c", "webrtc", "tcp", "udp", "quic". See
-    // `protocol ids <https://www.iana.org/assignments/tls-extensiontype-values/tls-extensiontype-values.xhtml#alpn-protocol-ids>`
+    // :ref: `protocol ids <https://www.iana.org/assignments/tls-extensiontype-values/tls-extensiontype-values.xhtml#alpn-protocol-ids>`
     // for details.
     string protocol = 11;
   }

--- a/api/external_auth.proto
+++ b/api/external_auth.proto
@@ -1,0 +1,236 @@
+syntax = "proto3";
+
+// [#proto-status: draft]
+
+package envoy.api.v2;
+
+
+import "google/protobuf/struct.proto";
+import "google/protobuf/timestamp.proto";
+import "google/rpc/status.proto";
+
+// Authorization service.
+// Primarily responds with OK or NOT OK.
+service Authorization {
+   rpc Check(CheckRequest) returns (CheckResponse);
+}
+
+message CheckRequest {
+    // The name of the tenant for multi-tenant support.
+    string tenant_name = 1;
+
+    // The request attributes.
+    AttributeContext attributes = 2;
+}
+
+message CheckResponse {
+    // Status OK allows the request. Any other response indicates the request should be denied.
+    google.rpc.Status status = 1;
+}
+
+// An attribute is a piece of metadata that describes an activity on a network.
+// For example, the size of an HTTP request, or the status code of an HTTP response.
+//
+// Each attribute has a type and a name, which is logically defined as a proto message field.
+// The fields follow the Istio attribute vocabulary.
+// https://istio.io/docs/reference/config/mixer/attribute-vocabulary.html
+// The field type becomes the attribute type, and the field path becomes the attribute name.
+// For example, the attribute `source.ip` maps to field `AttributeContext.source.ip`.
+message AttributeContext {
+  // This message defines attributes for a node that handles a network request.
+  // The node can be either a service or an application that sends, forwards,
+  // or receives the request. Service peers should fill in the `service`,
+  // `principal`, and `labels` as appropriate.
+  message Peer {
+    // The IP address of the peer.
+    string ip = 1;
+
+    // The network port of the peer.
+    int64 port = 2;
+
+    // The canonical service name of the peer.
+    string service = 3;
+
+    // The labels associated with the peer.
+    // These could be pod labels for Kubernetes or tags for VMs.
+    // The source of the labels could be an X.509 certificate or other configuration.
+    map<string, string> labels = 4;
+
+    // The identity of this peer. Similar to `Request.auth.principal`, but
+    // relative to the peer instead of the request. For example, the
+    // the identity associated with the workload.
+    // This field can be sourced from the `Subject Aleternative Names` of an X.509 certificate. 
+    repeated string principals = 5;
+
+    // Other claims about the peer that are not captured in labels and principals.
+    google.protobuf.Struct claims = 6;
+
+    // The CLDR country/region code associated with the above IP address.
+    // If the IP address is private, the `region_code` should reflect the
+    // physical location where this peer is running.
+    string region_code = 7;
+  }
+
+  // This message defines request authentication attributes. Terminology is
+  // based on the JSON Web Token (JWT) standard, but the terms also
+  // correlate to concepts in other standards.
+  message Auth {
+    // The authenticated principal. Reflects the issuer (`iss`) and subject
+    // (`sub`) claims within a JWT, usually by joining them with a `/`.
+    string principal = 1;
+
+    // The intended audience(s) for this authentication information. Reflects
+    // the audience (`aud`) claim within a JWT. The audience
+    // value(s) depends on the `issuer`, but typically include one or more of
+    // the following pieces of information:
+    //
+    // *  The services intended to receive the credential such as
+    //    ["pubsub.googleapis.com", "storage.googleapis.com"]
+    // *  A set of service-based scopes. For example,
+    //    ["https://www.googleapis.com/auth/cloud-platform"]
+    // *  The client id of an app, such as the Firebase project id for JWTs
+    //    from Firebase Auth.
+    //
+    repeated string audiences = 2;
+
+    // The authorized presenter of the credential. Reflects the optional
+    // Authorized Presenter (`azp`) claim within a JWT or the
+    // OAuth client id. For example, a Google Cloud Platform client id looks
+    // as follows: "123456789012.apps.googleusercontent.com".
+    string presenter = 3;
+
+    // Structured claims presented with the credential. JWTs include
+    // `{key: value}` pairs for standard and private claims. The following
+    // is a subset of the standard required and optional claims that would
+    // typically be presented for a Google-based JWT:
+    //
+    //    {'iss': 'accounts.google.com',
+    //     'sub': '113289723416554971153',
+    //     'aud': ['123456789012', 'pubsub.googleapis.com'],
+    //     'azp': '123456789012.apps.googleusercontent.com',
+    //     'email': 'jsmith@example.com',
+    //     'iat': 1353601026,
+    //     'exp': 1353604926}
+    //
+    // SAML assertions are similarly specified, but with an identity provider
+    // dependent structure.
+    google.protobuf.Struct claims = 4;
+  }
+
+  // This message defines attributes for an HTTP request. If the actual
+  // request is not an HTTP request, the runtime system should try to map
+  // the actual request to an equivalent HTTP request.
+  message Request {
+    // The unique ID for a request, which can be propagated to downstream
+    // systems. The ID should have low probability of collision
+    // within a single day for a specific service.
+    // For http it will be X-Request-ID or equivalent.
+    // For tcp is should be a connection id.
+    string id = 1;
+
+    // The HTTP request method, such as `GET`, `POST`.
+    string method = 2;
+
+    // The HTTP request headers. If multiple headers share the same key, they
+    // must be merged according to the HTTP spec. All header keys must be
+    // lowercased, because HTTP header keys are case-insensitive.
+    map<string, string> headers = 3;
+
+    // The HTTP URL path.
+    string path = 4;
+
+    // The HTTP request `Host` or 'Authority` header value.
+    string host = 5;
+
+    // The HTTP URL scheme, such as `http` and `https`.
+    string scheme = 6;
+
+    // The HTTP URL query in the format of `name1=value`&name2=value2`, as it
+    // appears in the first line of the HTTP request. No decoding is performed.
+    string query = 7;
+
+    // The HTTP URL fragment. No URL decoding is performed.
+    string fragment = 8;
+
+    // The timestamp when the `destination` service receives the first byte of
+    // the request.
+    google.protobuf.Timestamp time = 9;
+
+    // The HTTP request size in bytes. If unknown, it must be -1.
+    int64 size = 10;
+
+    // The network protocol used with the request, such as "http/1.1",
+    // "spdy/3", "h2", "h2c", "webrtc", "tcp", "udp", "quic". See
+    // https://www.iana.org/assignments/tls-extensiontype-values/tls-extensiontype-values.xhtml#alpn-protocol-ids
+    // for details.
+    string protocol = 11;
+
+    // A special parameter for request reason. It is used by security systems
+    // to associate auditing information with a request.
+    string reason = 12;
+
+    // The request authentication. May be absent for unauthenticated requests.
+    // Derived from the HTTP request `Authorization` header or equivalent.
+    Auth auth = 13;
+
+    // API key used for this request.
+    string api_key = 14;
+  }
+
+  // Api models the external API surface of a service.
+  message Api {
+    // The public service name. This is distinct from the in-mesh service identity
+    // and reflects the name of the service exposed to the client.
+    // example: mypetstore.com
+    string service = 1;
+
+    // version of the service.
+    string version = 2;
+
+    // Unique string used to identify the operation.
+    // The id is unique among all operations described in a specific <service, version>.
+    // example: `getPetsById`
+    string operation = 3;
+
+    // The protocol type of the API call. Mainly for monitoring/analytics.
+    // Note that this is the frontend protocol exposed to the client, not the protocol implemented by the backend service.
+    // example: `http`, `grpc`
+    string protocol = 4;
+  }
+
+  // The source of a network activity, such as starting a TCP connection.
+  // In a multi hop network activity, the source represents the sender of the
+  // last hop.
+  Peer source = 1;
+
+  // The destination of a network activity, such as accepting a TCP connection.
+  // In a multi hop network activity, the destination represents the receiver of
+  // the last hop.
+  Peer destination = 2;
+
+  // The origin of a network activity. In a multi hop network activity,
+  // the origin represents the sender of the first hop. For the first hop,
+  // the `source` and the `origin` must have the same content.
+  Peer origin = 3; 
+
+  // Represents a network request, such as an HTTP request.
+  Request request = 4;
+
+  // Api information extracted using the api spec.
+  Api api = 5;
+
+  // This is analogous to request.headers, however these contents will not be sent to the upstream server.
+  // request_context provides an extension mechanism for sending additional information to the auth server
+  // without adding it to request.headers.
+  // request_context may map to the internal opaque context in the filter chain.
+  map<string, string> request_context = 10;
+}
+
+
+// The following items are left out of this proto
+// Caching Protocol
+// request_context return values to inject back into the filter chain
+// Configuration
+// - field mask to send
+// - which return values from request_context are copied back
+// - which return values are copied into request_headers

--- a/api/external_auth.proto
+++ b/api/external_auth.proto
@@ -4,7 +4,6 @@ syntax = "proto3";
 
 package envoy.api.v2;
 
-
 import "google/protobuf/struct.proto";
 import "google/protobuf/timestamp.proto";
 import "google/rpc/status.proto";
@@ -12,20 +11,20 @@ import "google/rpc/status.proto";
 // Authorization service.
 // Primarily responds with OK or NOT OK.
 service Authorization {
-   rpc Check(CheckRequest) returns (CheckResponse);
+  rpc Check(CheckRequest) returns (CheckResponse);
 }
 
 message CheckRequest {
-    // The name of the tenant for multi-tenant support.
-    string tenant_name = 1;
+  // The name of the tenant for multi-tenant support.
+  string tenant_name = 1;
 
-    // The request attributes.
-    AttributeContext attributes = 2;
+  // The request attributes.
+  AttributeContext attributes = 2;
 }
 
 message CheckResponse {
-    // Status OK allows the request. Any other response indicates the request should be denied.
-    google.rpc.Status status = 1;
+  // Status OK allows the request. Any other response indicates the request should be denied.
+  google.rpc.Status status = 1;
 }
 
 // An attribute is a piece of metadata that describes an activity on a network.
@@ -133,10 +132,10 @@ message AttributeContext {
   // Represents a network request, such as an HTTP request.
   Request request = 4;
 
-  // This is analogous to request.headers, however these contents will not be sent to the upstream server.
-  // request_context provides an extension mechanism for sending additional information to the auth server
-  // without adding it to request.headers.
-  // request_context may map to the internal opaque context in the filter chain.
+  // This is analogous to request.headers, however these contents will not be sent to the upstream
+  // server. request_context provides an extension mechanism for sending additional information to
+  // the auth server without adding it to request.headers. request_context may map to the internal
+  // opaque context in the filter chain.
   map<string, string> request_context = 10;
 }
 

--- a/api/external_auth.proto
+++ b/api/external_auth.proto
@@ -4,6 +4,7 @@ syntax = "proto3";
 
 package envoy.api.v2;
 
+import "api/address.proto";
 import "google/protobuf/struct.proto";
 import "google/protobuf/timestamp.proto";
 import "google/rpc/status.proto";
@@ -35,21 +36,21 @@ message AttributeContext {
   // or receives the request. Service peers should fill in the `service`,
   // `principal`, and `labels` as appropriate.
   message Peer {
-    // The IP address of the peer.
-    string ip = 1;
-
-    // The network port of the peer.
-    int64 port = 2;
+    // The address of the peer, this is typically the IP address.
+    // It can also be UDS, or others.
+    Address address = 1;
 
     // The canonical service name of the peer.
-    // It should be set to :ref:`x-envoy-downstream-service-cluster <https://www.envoyproxy.io/docs/envoy/latest/configuration/http_conn_man/headers#x-envoy-downstream-service-cluster>`
-    // If a more trusted source of the service name is available through mTLS/secure naming, it should be used.
-    string service = 3;
+    // It should be set to :ref:`x-envoy-downstream-service-cluster
+    // <https://www.envoyproxy.io/docs/envoy/latest/configuration/http_conn_man/headers#x-envoy-downstream-service-cluster>`
+    // If a more trusted source of the service name is available through mTLS/secure naming, it
+    // should be used.
+    string service = 2;
 
     // The labels associated with the peer.
     // These could be pod labels for Kubernetes or tags for VMs.
     // The source of the labels could be an X.509 certificate or other configuration.
-    map<string, string> labels = 4;
+    map<string, string> labels = 3;
 
     // The authenticated identity of this peer.
     // For example, the identity associated with the workload such as a service account.
@@ -60,20 +61,29 @@ message AttributeContext {
     // For example
     // SPIFFE format is `spiffe://trust-domain/path`
     // Google account format is `https://accounts.google.com/{userid}`
-    string principal = 5;
+    string principal = 4;
 
     // Other claims about the peer that are not captured in labels and principal.
-    google.protobuf.Struct claims = 6;
+    google.protobuf.Struct claims = 5;
   }
 
-  // This message defines attributes for an HTTP request. If the actual
-  // request is not an HTTP request, the runtime system should try to map
-  // the actual request to an equivalent HTTP request.
+  // Represents a network request, such as an HTTP request.
   message Request {
+    oneof request {
+      HTTPRequest http_request = 1;
+    }
+    // The timestamp when the `destination` service receives the first byte of
+    // the request.
+    google.protobuf.Timestamp time = 2;
+  }
+
+  // This message defines attributes for an HTTP request.
+  // HTTP, H2, grpc are all considered http requests.
+  message HTTPRequest {
     // The unique ID for a request, which can be propagated to downstream
     // systems. The ID should have low probability of collision
     // within a single day for a specific service.
-    // For http it will be X-Request-ID or equivalent.
+    // For http it should be X-Request-ID or equivalent.
     // For tcp is should be a connection id.
     string id = 1;
 
@@ -101,18 +111,12 @@ message AttributeContext {
     // The HTTP URL fragment. No URL decoding is performed.
     string fragment = 8;
 
-    // The timestamp when the `destination` service receives the first byte of
-    // the request.
-    google.protobuf.Timestamp time = 9;
-
     // The HTTP request size in bytes. If unknown, it must be -1.
-    int64 size = 10;
+    int64 size = 9;
 
-    // The network protocol used with the request, such as "http/1.1",
-    // "spdy/3", "h2", "h2c", "webrtc", "tcp", "udp", "quic". See
-    // :ref: `protocol ids <https://www.iana.org/assignments/tls-extensiontype-values/tls-extensiontype-values.xhtml#alpn-protocol-ids>`
-    // for details.
-    string protocol = 11;
+    // The network protocol used with the request, such as
+    // "http/1.1", "spdy/3", "h2", "h2c"
+    string protocol = 10;
   }
 
   // The source of a network activity, such as starting a TCP connection.
@@ -128,11 +132,11 @@ message AttributeContext {
   // Represents a network request, such as an HTTP request.
   Request request = 4;
 
-  // This is analogous to request.headers, however these contents will not be sent to the upstream
-  // server. request_context provides an extension mechanism for sending additional information to
-  // the auth server without adding it to request.headers. request_context may map to the internal
+  // This is analogous to http_request.headers, however these contents will not be sent to the
+  // upstream server. Context_extensions provide an extension mechanism for sending additional
+  // information to the auth server without modifying the proto definition. It maps to the internal
   // opaque context in the filter chain.
-  map<string, string> request_context = 10;
+  map<string, string> context_extensions = 10;
 }
 
 // The following items are left out of this proto

--- a/api/external_auth.proto
+++ b/api/external_auth.proto
@@ -56,10 +56,10 @@ message AttributeContext {
     // The source of the labels could be an X.509 certificate or other configuration.
     map<string, string> labels = 4;
 
-    // The identity of this peer. Similar to `Request.auth.principal`, but
-    // relative to the peer instead of the request. For example, the
-    // the identity associated with the workload.
-    // This field can be sourced from the `Subject Aleternative Names` of an X.509 certificate. 
+    // The validated identity of this peer.
+    // For example, the identity associated with the workload such as a service account.
+    // If an X.509 certificate is used to assert the identity this field should be sourced from
+    // `Subject` and `Subject Alternative Names`.
     repeated string principals = 5;
 
     // Other claims about the peer that are not captured in labels and principals.
@@ -69,52 +69,6 @@ message AttributeContext {
     // If the IP address is private, the `region_code` should reflect the
     // physical location where this peer is running.
     string region_code = 7;
-  }
-
-  // This message defines request authentication attributes. Terminology is
-  // based on the JSON Web Token (JWT) standard, but the terms also
-  // correlate to concepts in other standards.
-  message Auth {
-    // The authenticated principal. Reflects the issuer (`iss`) and subject
-    // (`sub`) claims within a JWT, usually by joining them with a `/`.
-    string principal = 1;
-
-    // The intended audience(s) for this authentication information. Reflects
-    // the audience (`aud`) claim within a JWT. The audience
-    // value(s) depends on the `issuer`, but typically include one or more of
-    // the following pieces of information:
-    //
-    // *  The services intended to receive the credential such as
-    //    ["pubsub.googleapis.com", "storage.googleapis.com"]
-    // *  A set of service-based scopes. For example,
-    //    ["https://www.googleapis.com/auth/cloud-platform"]
-    // *  The client id of an app, such as the Firebase project id for JWTs
-    //    from Firebase Auth.
-    //
-    repeated string audiences = 2;
-
-    // The authorized presenter of the credential. Reflects the optional
-    // Authorized Presenter (`azp`) claim within a JWT or the
-    // OAuth client id. For example, a Google Cloud Platform client id looks
-    // as follows: "123456789012.apps.googleusercontent.com".
-    string presenter = 3;
-
-    // Structured claims presented with the credential. JWTs include
-    // `{key: value}` pairs for standard and private claims. The following
-    // is a subset of the standard required and optional claims that would
-    // typically be presented for a Google-based JWT:
-    //
-    //    {'iss': 'accounts.google.com',
-    //     'sub': '113289723416554971153',
-    //     'aud': ['123456789012', 'pubsub.googleapis.com'],
-    //     'azp': '123456789012.apps.googleusercontent.com',
-    //     'email': 'jsmith@example.com',
-    //     'iat': 1353601026,
-    //     'exp': 1353604926}
-    //
-    // SAML assertions are similarly specified, but with an identity provider
-    // dependent structure.
-    google.protobuf.Struct claims = 4;
   }
 
   // This message defines attributes for an HTTP request. If the actual
@@ -164,38 +118,6 @@ message AttributeContext {
     // https://www.iana.org/assignments/tls-extensiontype-values/tls-extensiontype-values.xhtml#alpn-protocol-ids
     // for details.
     string protocol = 11;
-
-    // A special parameter for request reason. It is used by security systems
-    // to associate auditing information with a request.
-    string reason = 12;
-
-    // The request authentication. May be absent for unauthenticated requests.
-    // Derived from the HTTP request `Authorization` header or equivalent.
-    Auth auth = 13;
-
-    // API key used for this request.
-    string api_key = 14;
-  }
-
-  // Api models the external API surface of a service.
-  message Api {
-    // The public service name. This is distinct from the in-mesh service identity
-    // and reflects the name of the service exposed to the client.
-    // example: mypetstore.com
-    string service = 1;
-
-    // version of the service.
-    string version = 2;
-
-    // Unique string used to identify the operation.
-    // The id is unique among all operations described in a specific <service, version>.
-    // example: `getPetsById`
-    string operation = 3;
-
-    // The protocol type of the API call. Mainly for monitoring/analytics.
-    // Note that this is the frontend protocol exposed to the client, not the protocol implemented by the backend service.
-    // example: `http`, `grpc`
-    string protocol = 4;
   }
 
   // The source of a network activity, such as starting a TCP connection.
@@ -208,16 +130,8 @@ message AttributeContext {
   // the last hop.
   Peer destination = 2;
 
-  // The origin of a network activity. In a multi hop network activity,
-  // the origin represents the sender of the first hop. For the first hop,
-  // the `source` and the `origin` must have the same content.
-  Peer origin = 3; 
-
   // Represents a network request, such as an HTTP request.
   Request request = 4;
-
-  // Api information extracted using the api spec.
-  Api api = 5;
 
   // This is analogous to request.headers, however these contents will not be sent to the upstream server.
   // request_context provides an extension mechanism for sending additional information to the auth server
@@ -226,8 +140,10 @@ message AttributeContext {
   map<string, string> request_context = 10;
 }
 
-
 // The following items are left out of this proto
+// Request.Auth field for jwt tokens
+// Request.Api for api management
+// Origin peer that originated the request
 // Caching Protocol
 // request_context return values to inject back into the filter chain
 // Configuration

--- a/api/rds.proto
+++ b/api/rds.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package envoy.api.v2;
 
-import "api/auth.proto";
+import "api/auth/auth.proto";
 import "api/base.proto";
 import "api/discovery.proto";
 
@@ -156,7 +156,7 @@ message VirtualHost {
 
   // [#not-implemented-hide:]
   // Return a 401/403 when auth checks fail.
-  AuthAction auth = 9;
+  auth.AuthAction auth = 9;
 }
 
 // A route is both a specification of how to match a request as well as an indication of what to do
@@ -192,7 +192,7 @@ message Route {
 
   // [#not-implemented-hide:]
   // Return a 401/403 when auth checks fail.
-  AuthAction auth = 6;
+  auth.AuthAction auth = 6;
 }
 
 // Compared to the :ref:`cluster <envoy_api_field_RouteAction.cluster>` field that specifies a

--- a/bazel/api_build_system.bzl
+++ b/bazel/api_build_system.bzl
@@ -28,7 +28,11 @@ def api_py_proto_library(name, srcs = [], deps = [], has_services = 0):
         deps = [_LibrarySuffix(d, _PY_SUFFIX) for d in deps] + [
             "@com_lyft_protoc_gen_validate//validate:validate_py",
             "@googleapis//:http_api_protos_py",
+<<<<<<< HEAD
             "@com_github_gogo_protobuf//:gogo_proto_py",
+=======
+            "@googleapis//:rpc_status_protos_py",
+>>>>>>> Initial proposal for external auth filter
         ],
         visibility = ["//visibility:public"],
     )
@@ -53,7 +57,12 @@ def api_proto_library(name, srcs = [], deps = [], has_services = 0, require_py =
             "@com_google_protobuf//:timestamp_proto",
             "@com_google_protobuf//:wrappers_proto",
             "@googleapis//:http_api_protos_proto",
+<<<<<<< HEAD
             "@com_github_gogo_protobuf//:gogo_proto",
+=======
+            "@googleapis//:http_api_protos_lib",
+            "@googleapis//:rpc_status_protos_lib",
+>>>>>>> Initial proposal for external auth filter
             "@com_lyft_protoc_gen_validate//validate:validate_proto",
         ],
         visibility = ["//visibility:public"],

--- a/bazel/api_build_system.bzl
+++ b/bazel/api_build_system.bzl
@@ -28,11 +28,8 @@ def api_py_proto_library(name, srcs = [], deps = [], has_services = 0):
         deps = [_LibrarySuffix(d, _PY_SUFFIX) for d in deps] + [
             "@com_lyft_protoc_gen_validate//validate:validate_py",
             "@googleapis//:http_api_protos_py",
-<<<<<<< HEAD
-            "@com_github_gogo_protobuf//:gogo_proto_py",
-=======
             "@googleapis//:rpc_status_protos_py",
->>>>>>> Initial proposal for external auth filter
+            "@com_github_gogo_protobuf//:gogo_proto_py",
         ],
         visibility = ["//visibility:public"],
     )
@@ -57,15 +54,8 @@ def api_proto_library(name, srcs = [], deps = [], has_services = 0, require_py =
             "@com_google_protobuf//:timestamp_proto",
             "@com_google_protobuf//:wrappers_proto",
             "@googleapis//:http_api_protos_proto",
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "@com_github_gogo_protobuf//:gogo_proto",
-=======
-            "@googleapis//:http_api_protos_lib",
-=======
->>>>>>> Remove several fields that will not be used
             "@googleapis//:rpc_status_protos_lib",
->>>>>>> Initial proposal for external auth filter
+            "@com_github_gogo_protobuf//:gogo_proto",
             "@com_lyft_protoc_gen_validate//validate:validate_proto",
         ],
         visibility = ["//visibility:public"],
@@ -81,11 +71,8 @@ def api_proto_library(name, srcs = [], deps = [], has_services = 0, require_py =
         external_deps = [
             "@com_google_protobuf//:cc_wkt_protos",
             "@googleapis//:http_api_protos",
-<<<<<<< HEAD
-            "@com_github_gogo_protobuf//:gogo_proto_cc",
-=======
             "@googleapis//:rpc_status_protos",
->>>>>>> Remove several fields that will not be used
+            "@com_github_gogo_protobuf//:gogo_proto_cc",
         ],
         visibility = ["//visibility:public"],
     )

--- a/bazel/api_build_system.bzl
+++ b/bazel/api_build_system.bzl
@@ -58,9 +58,12 @@ def api_proto_library(name, srcs = [], deps = [], has_services = 0, require_py =
             "@com_google_protobuf//:wrappers_proto",
             "@googleapis//:http_api_protos_proto",
 <<<<<<< HEAD
+<<<<<<< HEAD
             "@com_github_gogo_protobuf//:gogo_proto",
 =======
             "@googleapis//:http_api_protos_lib",
+=======
+>>>>>>> Remove several fields that will not be used
             "@googleapis//:rpc_status_protos_lib",
 >>>>>>> Initial proposal for external auth filter
             "@com_lyft_protoc_gen_validate//validate:validate_proto",
@@ -78,7 +81,11 @@ def api_proto_library(name, srcs = [], deps = [], has_services = 0, require_py =
         external_deps = [
             "@com_google_protobuf//:cc_wkt_protos",
             "@googleapis//:http_api_protos",
+<<<<<<< HEAD
             "@com_github_gogo_protobuf//:gogo_proto_cc",
+=======
+            "@googleapis//:rpc_status_protos",
+>>>>>>> Remove several fields that will not be used
         ],
         visibility = ["//visibility:public"],
     )

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -73,7 +73,7 @@ proto_library(
 )
 cc_proto_library(
      name = "rpc_status_protos",
-     srcs = [":rpc_status_protos_src"],
+     srcs = ["google/rpc/status.proto"],
      default_runtime = "@com_google_protobuf//:protobuf",
      protoc = "@com_google_protobuf//:protoc",
      deps = [

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -57,7 +57,37 @@ py_proto_library(
     visibility = ["//visibility:public"],
     deps = ["@com_google_protobuf//:protobuf_python"],
 )
-        """,
+filegroup(
+     name = "rpc_status_protos_src",
+     srcs = [
+         "google/rpc/status.proto",
+     ],
+     visibility = ["//visibility:public"],
+)
+
+proto_library(
+     name = "rpc_status_protos_lib",
+     srcs = [":rpc_status_protos_src"],
+     deps = ["@com_google_protobuf//:any_proto"],
+     visibility = ["//visibility:public"],
+)
+cc_proto_library(
+     name = "rpc_status_protos",
+     deps = [":rpc_status_protos_lib"],
+     visibility = ["//visibility:public"],
+)
+py_proto_library(
+     name = "rpc_status_protos_py",
+     srcs = [
+         "google/rpc/status.proto",
+     ],
+     include = ".",
+     default_runtime = "@com_google_protobuf//:protobuf_python",
+     protoc = "@com_google_protobuf//:protoc",
+     visibility = ["//visibility:public"],
+     deps = ["@com_google_protobuf//:protobuf_python"],
+)
+""",
     )
 
     native.new_http_archive(

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -73,7 +73,12 @@ proto_library(
 )
 cc_proto_library(
      name = "rpc_status_protos",
-     deps = [":rpc_status_protos_lib"],
+     srcs = [":rpc_status_protos_src"],
+     default_runtime = "@com_google_protobuf//:protobuf",
+     protoc = "@com_google_protobuf//:protoc",
+     deps = [
+         "@com_google_protobuf//:cc_wkt_protos"
+     ],
      visibility = ["//visibility:public"],
 )
 py_proto_library(


### PR DESCRIPTION
This PR proposes an external auth filter API with the following characteristics.

1. All information related to authorization is schematized.
2. Information is schematized without using envoy-specific abstractions.
3. The api is aligned with Istio Authorization Check (Mixer Check) api.
4. Adds `map<string, string> request_context` to pass additional information to the server.

This is proposed as an alternative to https://github.com/envoyproxy/data-plane-api/pull/222

