### PR TITLE
pgv: bazel plumbing for PGV support, some PGV related fixups.

### DIFF
--- a/api/BUILD
+++ b/api/BUILD
@@ -98,7 +98,7 @@ api_proto_library(
     has_services = 1,
     deps = [
         ":base",
-        "@promotheus_metrics_model//:client_model_protos_lib",
+        "@promotheus_metrics_model//:client_model",
     ],
     require_py = 0,
 )

--- a/api/address.proto
+++ b/api/address.proto
@@ -11,7 +11,7 @@ import "validate/validate.proto";
 
 message Pipe {
   // Unix Domain Socket path.
-  string path = 1 [(validate.rules).string.min_len = 1];
+  string path = 1 [(validate.rules).string.min_bytes = 1];
 }
 
 message SocketAddress {
@@ -65,7 +65,7 @@ message Address {
 // the subnet mask for a `CIDR <https://tools.ietf.org/html/rfc4632>`_ range.
 message CidrRange {
   // IPv4 or IPv6 address, e.g. 192.0.0.0 or 2001:db8::.
-  string address_prefix = 1 [(validate.rules).string.min_len = 1];
+  string address_prefix = 1 [(validate.rules).string.min_bytes = 1];
   // Length of prefix, e.g. 0, 32.
   google.protobuf.UInt32Value prefix_len = 2 [(validate.rules).uint32.lte = 128];
 }

--- a/api/base.proto
+++ b/api/base.proto
@@ -35,9 +35,9 @@ message Locality {
 // configuration for serving.
 message Node {
   // An opaque node identifier for the Envoy node.
-  string id = 1 [(validate.rules).string.min_len = 1];
+  string id = 1 [(validate.rules).string.min_bytes = 1];
   // The cluster that the Envoy node belongs to.
-  string cluster = 2 [(validate.rules).string.min_len = 1];
+  string cluster = 2 [(validate.rules).string.min_bytes = 1];
   // Opaque metadata extending the node identifier. Envoy will pass this
   // directly to the management server.
   google.protobuf.Struct metadata = 3;
@@ -84,7 +84,7 @@ message RuntimeUInt32 {
   uint32 default_value = 2;
 
   // Runtime key to get value for comparison. This value is used if defined.
-  string runtime_key = 3 [(validate.rules).string.min_len = 1];
+  string runtime_key = 3 [(validate.rules).string.min_bytes = 1];
 }
 
 // Envoy supports :ref:`upstream priority routing
@@ -189,7 +189,7 @@ message ConfigSource {
 message TransportSocket {
   // The name of the transport socket to instantiate. The name must match a supported transport
   // socket implementation.
-  string name = 1 [(validate.rules).string.min_len = 1];
+  string name = 1 [(validate.rules).string.min_bytes = 1];
 
   // Implementation specific configuration which depends on the implementation being instantiated.
   // See the supported transport socket implementations for further documentation.

--- a/api/cds.proto
+++ b/api/cds.proto
@@ -84,7 +84,7 @@ message Cluster {
   // By default, the maximum length of a cluster name is limited to 60
   // characters. This limit can be increased by setting the
   // :option:`--max-obj-name-len` command line argument to the desired value.
-  string name = 1 [(validate.rules).string.min_len = 1];
+  string name = 1 [(validate.rules).string.min_bytes = 1];
 
   // Refer to :ref:`service discovery type <arch_overview_service_discovery_types>`
   // for an explanation on each type.
@@ -124,7 +124,7 @@ message Cluster {
     // Optional alternative to cluster name to present to EDS. This does not
     // have the same restrictions as cluster name, i.e. it may be arbritary
     // length.
-    string service_name = 2 [(validate.rules).string.min_len = 1];
+    string service_name = 2 [(validate.rules).string.min_bytes = 1];
   }
   // Configuration to use for EDS updates for the Cluster.
   EdsClusterConfig eds_cluster_config = 3;

--- a/api/eds.proto
+++ b/api/eds.proto
@@ -197,7 +197,7 @@ message UpstreamLocalityStats {
 // :ref:`LoadStatsRequest<envoy_api_msg_LoadStatsRequest>`
 message ClusterStats {
   // The name of the cluster.
-  string cluster_name = 1 [(validate.rules).string.min_len = 1];
+  string cluster_name = 1 [(validate.rules).string.min_bytes = 1];
 
   // Need at least one.
   repeated UpstreamLocalityStats upstream_locality_stats = 2 [(validate.rules).repeated.min_items = 1];
@@ -236,7 +236,7 @@ message LoadStatsRequest {
 // load_balancing_weight of its Locality.
 message ClusterLoadAssignment {
   // Name of the cluster.
-  string cluster_name = 1 [(validate.rules).string.min_len = 1];
+  string cluster_name = 1 [(validate.rules).string.min_bytes = 1];
 
   // List of endpoints to load balance to.
   repeated LocalityLbEndpoints endpoints = 2;
@@ -248,7 +248,7 @@ message ClusterLoadAssignment {
     // recover from an outage or should they be unable to autoscale and hence
     // overall incoming traffic volume need to be trimmed to protect them.
     // [#v2-api-diff: This is known as maintenance mode in v1.]
-    double drop_overload = 1 [(validate.rules).fixed32 = {gte:0, lte: 100}];
+    double drop_overload = 1 [(validate.rules).double = {gte:0, lte: 100}];
   }
 
   // Load balancing policy settings.

--- a/api/filter/http/fault.proto
+++ b/api/filter/http/fault.proto
@@ -41,17 +41,21 @@ message HTTPFault {
   string upstream_cluster = 3;
 
   // Specifies a set of headers that the filter should match on. The fault
-  // injection filter can be applied selectively to requests that match a set of headers specified in
-  // the fault filter config. The chances of actual fault injection further depend on the value of
-  // the :ref:`percent <envoy_api_field_filter.http.FaultAbort.percent>` field. The filter will check the request's headers
-  // against all the specified headers in the filter config. A match will happen if all the headers in
-  // the config are present in the request with the same values (or based on presence if the *value*
-  // field is not in the config).
-  repeated HeaderMatcher headers = 4 [(validate.rules).repeated.unique = true];
+  // injection filter can be applied selectively to requests that match a set of
+  // headers specified in the fault filter config. The chances of actual fault
+  // injection further depend on the value of the :ref:`percent
+  // <envoy_api_field_filter.http.FaultAbort.percent>` field. The filter will
+  // check the request's headers against all the specified headers in the filter
+  // config. A match will happen if all the headers in the config are present in
+  // the request with the same values (or based on presence if the *value* field
+  // is not in the config).
+  repeated HeaderMatcher headers = 4;
 
-  // Faults are injected for the specified list of downstream hosts. If this setting is
-  // not set, faults are injected for all downstream nodes. Downstream node name is taken from
-  // :ref:`the HTTP x-envoy-downstream-service-node <config_http_conn_man_headers_downstream-service-node>`
-  // header and compared against downstream_nodes list.
-  repeated string downstream_nodes = 5 [(validate.rules).repeated.unique = true];
+  // Faults are injected for the specified list of downstream hosts. If this
+  // setting is not set, faults are injected for all downstream nodes.
+  // Downstream node name is taken from :ref:`the HTTP
+  // x-envoy-downstream-service-node
+  // <config_http_conn_man_headers_downstream-service-node>` header and compared
+  // against downstream_nodes list.
+  repeated string downstream_nodes = 5;
 }

--- a/api/filter/http/health_check.proto
+++ b/api/filter/http/health_check.proto
@@ -16,7 +16,7 @@ message HealthCheck {
 
   // Specifies the incoming HTTP endpoint that should be considered the
   // health check endpoint. For example */healthcheck*.
-  string endpoint = 2 [(validate.rules).string.min_len = 1];
+  string endpoint = 2 [(validate.rules).string.min_bytes = 1];
 
   // If operating in pass through mode, the amount of time in milliseconds
   // that the filter should cache the upstream response.

--- a/api/filter/http/lua.proto
+++ b/api/filter/http/lua.proto
@@ -12,5 +12,5 @@ message Lua {
   // further loads code from disk if desired. Note that if JSON configuration is used, the code must
   // be properly escaped. YAML configuration may be easier to read since YAML supports multi-line
   // strings so complex scripts can be easily expressed inline in the configuration.
-  string inline_code = 1 [(validate.rules).string.min_len = 1];
+  string inline_code = 1 [(validate.rules).string.min_bytes = 1];
 }

--- a/api/filter/http/transcoder.proto
+++ b/api/filter/http/transcoder.proto
@@ -29,7 +29,7 @@ message GrpcJsonTranscoder {
   //   --descriptor_set_out=proto.pb test/proto/bookstore.proto
   //
   // If you have more than one proto source files, you can pass all of them in one command.
-  string proto_descriptor = 1 [(validate.rules).string.min_len = 1];
+  string proto_descriptor = 1 [(validate.rules).string.min_bytes = 1];
 
   // A list of strings that supplies the service names that the
   // transcoder will translate. If the service name doesn't exist in ``proto_descriptor``, Envoy

--- a/api/filter/network/http_connection_manager.proto
+++ b/api/filter/network/http_connection_manager.proto
@@ -25,7 +25,7 @@ message Rds {
   // API. This allows an Envoy configuration with multiple HTTP listeners (and
   // associated HTTP connection manager filters) to use different route
   // configurations.
-  string route_config_name = 2 [(validate.rules).string.min_len = 1];
+  string route_config_name = 2 [(validate.rules).string.min_bytes = 1];
 }
 
 message HttpFilter {
@@ -44,7 +44,7 @@ message HttpFilter {
   // * :ref:`envoy.lua <config_http_filters_lua>`
   // * :ref:`envoy.rate_limit <config_http_filters_rate_limit>`
   // * :ref:`envoy.router <config_http_filters_router>`
-  string name = 1 [(validate.rules).string.min_len = 1];
+  string name = 1 [(validate.rules).string.min_bytes = 1];
 
   // Filter specific configuration which depends on the filter being
   // instantiated. See the supported filters for further documentation.
@@ -85,7 +85,7 @@ message HttpConnectionManager {
   // The human readable prefix to use when emitting statistics for the
   // connection manager. See the :ref:`statistics documentation <config_http_conn_man_stats>` for
   // more information.
-  string stat_prefix = 2 [(validate.rules).string.min_len = 1];
+  string stat_prefix = 2 [(validate.rules).string.min_bytes = 1];
 
   oneof route_specifier {
     option (validate.required) = true;

--- a/api/filter/network/mongo_proxy.proto
+++ b/api/filter/network/mongo_proxy.proto
@@ -12,7 +12,7 @@ import "validate/validate.proto";
 message MongoProxy {
   // The human readable prefix to use when emitting :ref:`statistics
   // <config_network_filters_mongo_proxy_stats>`.
-  string stat_prefix = 1 [(validate.rules).string.min_len = 1];
+  string stat_prefix = 1 [(validate.rules).string.min_bytes = 1];
 
   // The optional path to use for writing Mongo access logs. If not access log
   // path is specified no access logs will be written. Note that access log is

--- a/api/filter/network/redis_proxy.proto
+++ b/api/filter/network/redis_proxy.proto
@@ -11,12 +11,12 @@ import "validate/validate.proto";
 
 message RedisProxy {
   // The prefix to use when emitting :ref:`statistics <config_network_filters_redis_proxy_stats>`.
-  string stat_prefix = 1 [(validate.rules).string.min_len = 1];
+  string stat_prefix = 1 [(validate.rules).string.min_bytes = 1];
 
   // Name of cluster from cluster manager. See the :ref:`configuration section
   // <arch_overview_redis_configuration>` of the architecture overview for recommendations on
   // configuring the backing cluster.
-  string cluster = 2 [(validate.rules).string.min_len = 1];
+  string cluster = 2 [(validate.rules).string.min_bytes = 1];
 
   // Redis connection pool settings.
   message ConnPoolSettings {

--- a/api/filter/network/tcp_proxy.proto
+++ b/api/filter/network/tcp_proxy.proto
@@ -18,10 +18,10 @@ import "validate/validate.proto";
 message TcpProxy {
   // The prefix to use when emitting :ref:`statistics
   // <config_network_filters_tcp_proxy_stats>`.
-  string stat_prefix = 1 [(validate.rules).string.min_len = 1];
+  string stat_prefix = 1 [(validate.rules).string.min_bytes = 1];
 
   // The upstream cluster to connect to.
-  string cluster = 2 [(validate.rules).string.min_len = 1];
+  string cluster = 2 [(validate.rules).string.min_bytes = 1];
 
   // [#not-implemented-hide:] The idle timeout for connections managed by the TCP proxy
   // filter. The idle timeout is defined as the period in which there is no
@@ -53,7 +53,7 @@ message TcpProxy {
     message TCPRoute {
       // The cluster to connect to when a the downstream network connection
       // matches the specified criteria.
-      string cluster = 1 [(validate.rules).string.min_len = 1];
+      string cluster = 1 [(validate.rules).string.min_bytes = 1];
 
       // An optional list of IP address subnets in the form
       // “ip_address/xx”. The criteria is satisfied if the destination IP

--- a/api/health_check.proto
+++ b/api/health_check.proto
@@ -46,7 +46,7 @@ message HealthCheck {
       option (validate.required) = true;
 
       // Hex encoded payload. E.g., "000000FF".
-      string text = 1 [(validate.rules).string.min_len = 1];
+      string text = 1 [(validate.rules).string.min_bytes = 1];
 
       // [#not-implemented-hide:] Binary payload.
       bytes binary = 2;
@@ -61,7 +61,7 @@ message HealthCheck {
 
     // Specifies the HTTP path that will be requested during health checking. For example
     // */healthcheck*.
-    string path = 2 [(validate.rules).string.min_len = 1];
+    string path = 2 [(validate.rules).string.min_bytes = 1];
 
     // [#not-implemented-hide:] HTTP specific payload.
     Payload send = 3;

--- a/api/lds.proto
+++ b/api/lds.proto
@@ -44,7 +44,7 @@ message Filter {
   // * :ref:`envoy.mongo_proxy <config_network_filters_mongo_proxy>`
   // * :ref:`envoy.redis_proxy <config_network_filters_redis_proxy>`
   // * :ref:`envoy.tcp_proxy <config_network_filters_tcp_proxy>`
-  string name = 1 [(validate.rules).string.min_len = 1];
+  string name = 1 [(validate.rules).string.min_bytes = 1];
 
   // Filter specific configuration which depends on the filter being
   // instantiated. See the supported filters for further documentation.

--- a/api/protocol.proto
+++ b/api/protocol.proto
@@ -6,6 +6,8 @@ package envoy.api.v2;
 
 import "google/protobuf/wrappers.proto";
 
+import "validate/validate.proto";
+
 // [#protodoc-title: Protocol options]
 
 // [#not-implemented-hide:]
@@ -30,7 +32,8 @@ message Http2ProtocolOptions {
   // `Maximum concurrent streams <http://httpwg.org/specs/rfc7540.html#rfc.section.5.1.2>`_
   // allowed for peer on one HTTP/2 connection. Valid values range from 1 to 2147483647 (2^31 - 1)
   // and defaults to 2147483647.
-  google.protobuf.UInt32Value max_concurrent_streams = 2;
+  google.protobuf.UInt32Value max_concurrent_streams = 2
+      [(validate.rules).uint32 = {gte: 1, lte: 2147483647}];
 
   // `Initial stream-level flow-control window
   // <http://httpwg.org/specs/rfc7540.html#rfc.section.6.9.2>`_ size. Valid values range from 65535
@@ -43,11 +46,13 @@ message Http2ProtocolOptions {
   // This field also acts as a soft limit on the number of bytes Envoy will buffer per-stream in the
   // HTTP/2 codec buffers.  Once the buffer reaches this pointer, watermark callbacks will fire to
   // stop the flow of data to the codec buffers.
-  google.protobuf.UInt32Value initial_stream_window_size = 3;
+  google.protobuf.UInt32Value initial_stream_window_size = 3
+      [(validate.rules).uint32 = {gte: 65535, lte: 2147483647}];
 
   // Similar to *initial_stream_window_size*, but for connection-level flow-control
   // window. Currently, this has the same minimum/maximum/default as *initial_stream_window_size*.
-  google.protobuf.UInt32Value initial_connection_window_size = 4;
+  google.protobuf.UInt32Value initial_connection_window_size = 4
+      [(validate.rules).uint32 = {gte: 65535, lte: 2147483647}];
 }
 
 // [#not-implemented-hide:]

--- a/api/rds.proto
+++ b/api/rds.proto
@@ -43,7 +43,7 @@ message WeightedCluster {
   message ClusterWeight {
     // Name of the upstream cluster. The cluster must exist in the
     // :ref:`cluster manager configuration <config_cluster_manager>`.
-    string name = 1 [(validate.rules).string.min_len = 1];
+    string name = 1 [(validate.rules).string.min_bytes = 1];
 
     // An integer between 0-100. When a request matches the route, the choice of
     // an upstream cluster is determined by its weight. The sum of weights
@@ -242,7 +242,7 @@ message RouteAction {
   message RequestMirrorPolicy {
     // Specifies the cluster that requests will be mirrored to. The cluster must
     // exist in the cluster manager configuration.
-    string cluster = 1 [(validate.rules).string.min_len = 1];
+    string cluster = 1 [(validate.rules).string.min_bytes = 1];
 
     // If not specified, all requests to the target cluster will be mirrored. If
     // specified, Envoy will lookup the runtime key to get the % of requests to
@@ -291,7 +291,7 @@ message RouteAction {
     message Header {
       // The name of the request header that will be used to obtain the hash
       // key. If the request header is not present, no hash will be produced.
-      string header_name = 1 [(validate.rules).string.min_len = 1];
+      string header_name = 1 [(validate.rules).string.min_bytes = 1];
     }
 
     // Envoy supports two types of cookie affinity:
@@ -312,7 +312,7 @@ message RouteAction {
       // The name of the cookie that will be used to obtain the hash key. If the
       // cookie is not present and ttl below is not set, no hash will be
       // produced.
-      string name = 1 [(validate.rules).string.min_len = 1];
+      string name = 1 [(validate.rules).string.min_bytes = 1];
 
       // If specified, a cookie with the TTL will be generated if the cookie is
       // not present.
@@ -410,7 +410,7 @@ message Decorator {
   //   For ingress (inbound) requests, or egress (outbound) responses, this value may be overridden
   //   by the :ref:`x-envoy-decorator-operation
   //   <config_http_filters_router_x-envoy-decorator-operation>` header.
-  string operation = 1 [(validate.rules).string.min_len = 1];
+  string operation = 1 [(validate.rules).string.min_bytes = 1];
 }
 
 // A route is both a specification of how to match a request as well as an indication of what to do
@@ -476,12 +476,12 @@ message VirtualCluster {
   // * The regex */rides/\d+* matches the path */rides/0*
   // * The regex */rides/\d+* matches the path */rides/123*
   // * The regex */rides/\d+* does not match the path */rides/123/456*
-  string pattern = 1 [(validate.rules).string.min_len = 1];
+  string pattern = 1 [(validate.rules).string.min_bytes = 1];
 
   //  Specifies the name of the virtual cluster. The virtual cluster name as well
   // as the virtual host name are used when emitting statistics. The statistics are emitted by the
   // router filter and are documented :ref:`here <config_http_filters_router_stats>`.
-  string name = 2 [(validate.rules).string.min_len = 1];
+  string name = 2 [(validate.rules).string.min_bytes = 1];
 
   // Optionally specifies the HTTP method to match on. For example GET, PUT,
   // etc.
@@ -540,10 +540,10 @@ message RateLimit {
       // The header name to be queried from the request headers. The header’s
       // value is used to populate the value of the descriptor entry for the
       // descriptor_key.
-      string header_name = 1 [(validate.rules).string.min_len = 1];
+      string header_name = 1 [(validate.rules).string.min_bytes = 1];
 
       // The key to use in the descriptor entry.
-      string descriptor_key = 2 [(validate.rules).string.min_len = 1];
+      string descriptor_key = 2 [(validate.rules).string.min_bytes = 1];
     }
 
     // The following descriptor entry is appended to the descriptor and is populated using the
@@ -561,7 +561,7 @@ message RateLimit {
     //   ("generic_key", "<descriptor_value>")
     message GenericKey {
       // The value to use in the descriptor entry.
-      string descriptor_value = 1 [(validate.rules).string.min_len = 1];
+      string descriptor_value = 1 [(validate.rules).string.min_bytes = 1];
     }
 
     // The following descriptor entry is appended to the descriptor:
@@ -571,7 +571,7 @@ message RateLimit {
     //   ("header_match", "<descriptor_value>")
     message HeaderValueMatch {
       // The value to use in the descriptor entry.
-      string descriptor_value = 1 [(validate.rules).string.min_len = 1];
+      string descriptor_value = 1 [(validate.rules).string.min_bytes = 1];
 
       // If set to true, the action will append a descriptor entry when the
       // request matches the headers. If set to false, the action will append a
@@ -616,7 +616,7 @@ message RateLimit {
   // cannot append a descriptor entry, no descriptor is generated for the
   // configuration. See :ref:`composing actions
   // <config_http_filters_rate_limit_composing_actions>` for additional documentation.
-  repeated Action actions = 3 [(validate.rules).string.min_len = 1];
+  repeated Action actions = 3 [(validate.rules).repeated.min_items = 1];
 }
 
 // .. attention::
@@ -637,7 +637,7 @@ message RateLimit {
 //     }
 message HeaderMatcher {
   // Specifies the name of the header in the request.
-  string name = 1 [(validate.rules).string.min_len = 1];
+  string name = 1 [(validate.rules).string.min_bytes = 1];
 
   // Specifies the value of the header. If the value is absent a request that
   // has the name header will match, regardless of the header’s value.
@@ -665,7 +665,7 @@ message HeaderMatcher {
 message VirtualHost {
   // The logical name of the virtual host. This is used when emitting certain
   // statistics but is not relevant for routing.
-  string name = 1 [(validate.rules).string.min_len = 1];
+  string name = 1 [(validate.rules).string.min_bytes = 1];
 
   // A list of domains (host/authority header) that will be matched to this
   // virtual host. Wildcard hosts are supported in the form of “*.foo.com” or

--- a/api/sds.proto
+++ b/api/sds.proto
@@ -31,7 +31,7 @@ message DataSource {
     option (validate.required) = true;
 
     // Local filesystem data source.
-    string filename = 1 [(validate.rules).string.min_len = 1];
+    string filename = 1 [(validate.rules).string.min_bytes = 1];
 
     // [#not-implemented-hide:]
     bytes inline = 2;

--- a/bazel/api_build_system.bzl
+++ b/bazel/api_build_system.bzl
@@ -1,4 +1,5 @@
 load("@com_google_protobuf//:protobuf.bzl", "py_proto_library")
+load("@com_lyft_protoc_gen_validate//bazel:pgv_proto_library.bzl", "pgv_cc_proto_library")
 
 def _CcSuffix(d):
     return d + "_cc"
@@ -27,6 +28,12 @@ def api_py_proto_library(name, srcs = [], deps = [], has_services = 0):
 # TODO(htuch): has_services is currently ignored but will in future support
 # gRPC stub generation.
 def api_proto_library(name, srcs = [], deps = [], has_services = 0, require_py = 1):
+    # This is now vestigial, since there are no direct consumers in
+    # data-plane-api. However, we want to maintain native proto_library support
+    # in the proto graph to (1) support future C++ use of native rules with
+    # cc_proto_library (or some Bazel aspect that works on proto_library) when
+    # it can play well with the PGV plugin and (2) other language support that
+    # can make use of native proto_library.
     native.proto_library(
         name = name,
         srcs = srcs,
@@ -37,14 +44,23 @@ def api_proto_library(name, srcs = [], deps = [], has_services = 0, require_py =
             "@com_google_protobuf//:struct_proto",
             "@com_google_protobuf//:timestamp_proto",
             "@com_google_protobuf//:wrappers_proto",
-            "@googleapis//:http_api_protos_lib",
+            "@googleapis//:http_api_protos_proto",
             "@com_lyft_protoc_gen_validate//validate:validate_proto",
         ],
         visibility = ["//visibility:public"],
     )
-    native.cc_proto_library(
+    # Under the hood, this is just an extension of the Protobuf library's
+    # bespoke cc_proto_library. It doesn't consume proto_library as a proto
+    # provider. Hopefully one day we can move to a model where this target and
+    # the proto_library above are aligned.
+    pgv_cc_proto_library(
         name = _CcSuffix(name),
-        deps = [name],
+        srcs = srcs,
+        deps = [_CcSuffix(d) for d in deps],
+        external_deps = [
+            "@com_google_protobuf//:cc_wkt_protos",
+            "@googleapis//:http_api_protos",
+        ],
         visibility = ["//visibility:public"],
     )
     if (require_py == 1):

--- a/test/validate/BUILD
+++ b/test/validate/BUILD
@@ -1,0 +1,14 @@
+load("//bazel:api_build_system.bzl", "api_cc_test", "api_proto_library")
+
+licenses(["notice"])  # Apache 2
+
+api_proto_library(
+    name = "test",
+    srcs = ["test.proto"],
+)
+
+api_cc_test(
+    name = "pgv_test",
+    srcs = ["pgv_test.cc"],
+    proto_deps = [":test"],
+)

--- a/test/validate/pgv_test.cc
+++ b/test/validate/pgv_test.cc
@@ -1,0 +1,35 @@
+#include <iostream>
+#include <cstdlib>
+
+#include "test/validate/test.pb.validate.h"
+
+// Basic protoc-gen-validate C++ validation header inclusion and Validate calls
+// from data-plane-api.
+// TODO(htuch): Switch to using real data-plane-api protos once we can support
+// the required field types.
+int main(int argc, char *argv[]) {
+  {
+    test::validate::Foo empty;
+
+    std::string err;
+    if (Validate(empty, &err)) {
+      std::cout << "Unexpected successful validation of empty proto."
+                << std::endl;
+      exit(EXIT_FAILURE);
+    }
+  }
+
+  {
+    test::validate::Foo non_empty;
+    non_empty.mutable_baz();
+
+    std::string err;
+    if (!Validate(non_empty, &err)) {
+      std::cout << "Unexpected failed validation of empty proto: " << err
+                << std::endl;
+      exit(EXIT_FAILURE);
+    }
+  }
+
+  exit(EXIT_SUCCESS);
+}

--- a/test/validate/test.proto
+++ b/test/validate/test.proto
@@ -1,0 +1,13 @@
+syntax = "proto3";
+
+package test.validate;
+
+import "validate/validate.proto";
+
+message Bar {
+  uint32 xyz = 1;
+}
+
+message Foo {
+  Bar baz = 1 [(.validate.rules).message.required = true];
+}

--- a/tools/protodoc/protodoc.py
+++ b/tools/protodoc/protodoc.py
@@ -496,7 +496,7 @@ def FormatFieldAsDefinitionListItem(outer_type_context, type_context, field):
   if field.options.HasExtension(validate_pb2.rules):
     rule = field.options.Extensions[validate_pb2.rules]
     if ((rule.HasField('message') and rule.message.required) or
-        (rule.HasField('string') and rule.string.min_len > 0) or
+        (rule.HasField('string') and rule.string.min_bytes > 0) or
         (rule.HasField('repeated') and rule.repeated.min_items > 0)):
       annotations.append('*REQUIRED*')
   leading_comment, comment_annotations = type_context.LeadingCommentPathLookup()


### PR DESCRIPTION
* Added PGV C++ generation support. This (hopefully temporarily)
  abandons using native proto_library in favor of pgv_cc_proto_library.
  We maintain build support for proto_library for the glorious future in
  which we write a Bazel aspect to run PGV against the native
  proto_library shadow graph.

* Replace min_len with min_bytes on strings, until PGV gets not-empty or
  min_len support for C++.

* Various fixups for places where the PGV plugin objected to
  annotations.

Signed-off-by: Harvey Tuch <htuch@google.com>