### PR TITLE
docs: reorder protos for easier top down reading

### DIFF
--- a/api/bootstrap.proto
+++ b/api/bootstrap.proto
@@ -19,6 +19,101 @@ import "google/protobuf/wrappers.proto";
 
 import "validate/validate.proto";
 
+// Bootstrap :ref:`configuration overview <config_overview_v2_bootstrap>`.
+message Bootstrap {
+  // Node identity to present to the management server and for instance
+  // identification purposes (e.g. in generated headers).
+  Node node = 1 [(validate.rules).message.required = true];
+
+  message StaticResources {
+    // Static :ref:`Listeners <envoy_api_msg_Listener>`. These listeners are
+    // available regardless of LDS configuration.
+    repeated Listener listeners = 1;
+
+    // If a network based configuration source is specified for :ref:`cds_config
+    // <envoy_api_field_Bootstrap.DynamicResources.cds_config>`, it's necessary
+    // to have some initial cluster definitions available to allow Envoy to know
+    // how to speak to the management server. These cluster definitions may not
+    // use :ref:`EDS <arch_overview_dynamic_config_sds>` (i.e. they should be static
+    // IP or DNS-based).
+    repeated Cluster clusters = 2;
+
+    // [#not-implemented-hide:]
+    repeated Secret secrets = 3;
+  }
+  // Statically specified resources.
+  StaticResources static_resources = 2;
+
+  message DynamicResources {
+    // All :ref:`Listeners <envoy_api_msg_Listener>` are provided by a single
+    // :ref:`LDS <arch_overview_dynamic_config_lds>` configuration source.
+    ConfigSource lds_config = 1;
+
+    // All post-bootstrap :ref:`Cluster <envoy_api_msg_Cluster>` definitions are
+    // provided by a single :ref:`CDS <arch_overview_dynamic_config_cds>`
+    // configuration source.
+    ConfigSource cds_config = 2;
+
+    // A single :ref:`ADS <config_overview_v2_ads>` source may be optionally
+    // specified. This must have :ref:`api_type
+    // <envoy_api_field_ApiConfigSource.api_type>` :ref:`GRPC
+    // <envoy_api_enum_value_ApiConfigSource.ApiType.GRPC>`. Only
+    // :ref:`ConfigSources <envoy_api_msg_ConfigSource>` that have
+    // the :ref:`ads <envoy_api_field_ConfigSource.ads>` field set will be
+    // streamed on the ADS channel.
+    ApiConfigSource ads_config = 3;
+
+    message DeprecatedV1 {
+      // This is the global :ref:`SDS <arch_overview_dynamic_config_sds>` config
+      // when using v1 REST for :ref:`CDS
+      // <arch_overview_dynamic_config_cds>`/:ref:`EDS
+      // <arch_overview_dynamic_config_sds>`.
+      ConfigSource sds_config = 1;
+    }
+    DeprecatedV1 deprecated_v1 = 4;
+  }
+  // xDS configuration sources.
+  DynamicResources dynamic_resources = 3;
+
+  // Configuration for the cluster manager which owns all upstream clusters
+  // within the server.
+  ClusterManager cluster_manager = 4 [(validate.rules).message.required = true];
+
+  // Optional file system path to search for startup flag files.
+  string flags_path = 5;
+
+  // Optional set of stats sinks.
+  repeated StatsSink stats_sinks = 6;
+
+  // Configuration for internal processing of stats.
+  StatsConfig stats_config = 13;
+
+  // Optional duration between flushes to configured stats sinks. For
+  // performance reasons Envoy latches counters and only flushes counters and
+  // gauges at a periodic interval. If not specified the default is 5000ms (5
+  // seconds).
+  google.protobuf.Duration stats_flush_interval = 7;
+
+  // Optional watchdog configuration.
+  Watchdog watchdog = 8;
+
+  // Configuration for an external tracing provider. If not specified, no
+  // tracing will be performed.
+  Tracing tracing = 9;
+
+  // Configuration for an external rate limit service provider. If not
+  // specified, any calls to the rate limit service will immediately return
+  // success.
+  RateLimitServiceConfig rate_limit_service = 10;
+
+  // Configuration for the runtime configuration provider. If not specified, a
+  // “null” provider will be used which will result in all defaults being used.
+  Runtime runtime = 11;
+
+  // Configuration for the local administration HTTP server.
+  Admin admin = 12 [(validate.rules).message.required = true];
+}
+
 // Configuration for the LightStep tracer.
 message LightstepConfig {
   // The cluster manager cluster that hosts the LightStep collectors.
@@ -285,99 +380,4 @@ message RateLimitServiceConfig {
   // service. The client will connect to this cluster when it needs to make rate
   // limit service requests.
   string cluster_name = 1 [(validate.rules).string.min_len = 1];
-}
-
-// Bootstrap :ref:`configuration overview <config_overview_v2_bootstrap>`.
-message Bootstrap {
-  // Node identity to present to the management server and for instance
-  // identification purposes (e.g. in generated headers).
-  Node node = 1 [(validate.rules).message.required = true];
-
-  message StaticResources {
-    // Static :ref:`Listeners <envoy_api_msg_Listener>`. These listeners are
-    // available regardless of LDS configuration.
-    repeated Listener listeners = 1;
-
-    // If a network based configuration source is specified for :ref:`cds_config
-    // <envoy_api_field_Bootstrap.DynamicResources.cds_config>`, it's necessary
-    // to have some initial cluster definitions available to allow Envoy to know
-    // how to speak to the management server. These cluster definitions may not
-    // use :ref:`EDS <arch_overview_dynamic_config_sds>` (i.e. they should be static
-    // IP or DNS-based).
-    repeated Cluster clusters = 2;
-
-    // [#not-implemented-hide:]
-    repeated Secret secrets = 3;
-  }
-  // Statically specified resources.
-  StaticResources static_resources = 2;
-
-  message DynamicResources {
-    // All :ref:`Listeners <envoy_api_msg_Listener>` are provided by a single
-    // :ref:`LDS <arch_overview_dynamic_config_lds>` configuration source.
-    ConfigSource lds_config = 1;
-
-    // All post-bootstrap :ref:`Cluster <envoy_api_msg_Cluster>` definitions are
-    // provided by a single :ref:`CDS <arch_overview_dynamic_config_cds>`
-    // configuration source.
-    ConfigSource cds_config = 2;
-
-    // A single :ref:`ADS <config_overview_v2_ads>` source may be optionally
-    // specified. This must have :ref:`api_type
-    // <envoy_api_field_ApiConfigSource.api_type>` :ref:`GRPC
-    // <envoy_api_enum_value_ApiConfigSource.ApiType.GRPC>`. Only
-    // :ref:`ConfigSources <envoy_api_msg_ConfigSource>` that have
-    // the :ref:`ads <envoy_api_field_ConfigSource.ads>` field set will be
-    // streamed on the ADS channel.
-    ApiConfigSource ads_config = 3;
-
-    message DeprecatedV1 {
-      // This is the global :ref:`SDS <arch_overview_dynamic_config_sds>` config
-      // when using v1 REST for :ref:`CDS
-      // <arch_overview_dynamic_config_cds>`/:ref:`EDS
-      // <arch_overview_dynamic_config_sds>`.
-      ConfigSource sds_config = 1;
-    }
-    DeprecatedV1 deprecated_v1 = 4;
-  }
-  // xDS configuration sources.
-  DynamicResources dynamic_resources = 3;
-
-  // Configuration for the cluster manager which owns all upstream clusters
-  // within the server.
-  ClusterManager cluster_manager = 4 [(validate.rules).message.required = true];
-
-  // Optional file system path to search for startup flag files.
-  string flags_path = 5;
-
-  // Optional set of stats sinks.
-  repeated StatsSink stats_sinks = 6;
-
-  // Configuration for internal processing of stats.
-  StatsConfig stats_config = 13;
-
-  // Optional duration between flushes to configured stats sinks. For
-  // performance reasons Envoy latches counters and only flushes counters and
-  // gauges at a periodic interval. If not specified the default is 5000ms (5
-  // seconds).
-  google.protobuf.Duration stats_flush_interval = 7;
-
-  // Optional watchdog configuration.
-  Watchdog watchdog = 8;
-
-  // Configuration for an external tracing provider. If not specified, no
-  // tracing will be performed.
-  Tracing tracing = 9;
-
-  // Configuration for an external rate limit service provider. If not
-  // specified, any calls to the rate limit service will immediately return
-  // success.
-  RateLimitServiceConfig rate_limit_service = 10;
-
-  // Configuration for the runtime configuration provider. If not specified, a
-  // “null” provider will be used which will result in all defaults being used.
-  Runtime runtime = 11;
-
-  // Configuration for the local administration HTTP server.
-  Admin admin = 12 [(validate.rules).message.required = true];
 }

--- a/api/cds.proto
+++ b/api/cds.proto
@@ -31,49 +31,6 @@ service ClusterDiscoveryService {
   }
 }
 
-// An extensible structure containing the address Envoy should bind to when
-// establishing upstream connections.
-message UpstreamBindConfig {
-  // The address Envoy should bind to when establishing upstream connections.
-  Address source_address = 1;
-}
-
-// :ref:`Circuit breaking<arch_overview_circuit_break>` settings can be
-// specified individually for each defined priority.
-message CircuitBreakers {
-
-  // A Thresholds defines CircuitBreaker settings for a
-  // :ref:`RoutingPriority<envoy_api_enum_RoutingPriority>`.
-  message Thresholds {
-    // The :ref:`RoutingPriority<envoy_api_enum_RoutingPriority>`
-    // the specified CircuitBreaker settings apply to.
-    RoutingPriority priority = 1;
-
-    // The maximum number of connections that Envoy will make to the upstream
-    // cluster. If not specified, the default is 1024.
-    google.protobuf.UInt32Value max_connections = 2;
-
-    // The maximum number of pending requests that Envoy will allow to the
-    // upstream cluster. If not specified, the default is 1024.
-    google.protobuf.UInt32Value max_pending_requests = 3;
-
-    // The maximum number of parallel requests that Envoy will make to the
-    // upstream cluster. If not specified, the default is 1024.
-    google.protobuf.UInt32Value max_requests = 4;
-
-    // The maximum number of parallel retries that Envoy will allow to the
-    // upstream cluster. If not specified, the default is 3.
-    google.protobuf.UInt32Value max_retries = 5;
-  }
-
-  // If multiple :ref:`Thresholds<envoy_api_msg_CircuitBreakers.Thresholds>`
-  // are defined with the same :ref:`RoutingPriority<envoy_api_enum_RoutingPriority>`,
-  // the first one in the list is used. If no Thresholds is defined for a given
-  // :ref:`RoutingPriority<envoy_api_enum_RoutingPriority>`, the default values
-  // are used.
-  repeated Thresholds thresholds = 1;
-}
-
 message Cluster {
   // Supplies the name of the cluster which must be unique across all clusters.
   // The cluster name is used when emitting
@@ -447,4 +404,47 @@ message Cluster {
   // For instance, if the metadata is intended for the Router filter, the filter
   // name should be specified as *envoy.router*.
   Metadata metadata = 25;
+}
+
+// An extensible structure containing the address Envoy should bind to when
+// establishing upstream connections.
+message UpstreamBindConfig {
+  // The address Envoy should bind to when establishing upstream connections.
+  Address source_address = 1;
+}
+
+// :ref:`Circuit breaking<arch_overview_circuit_break>` settings can be
+// specified individually for each defined priority.
+message CircuitBreakers {
+
+  // A Thresholds defines CircuitBreaker settings for a
+  // :ref:`RoutingPriority<envoy_api_enum_RoutingPriority>`.
+  message Thresholds {
+    // The :ref:`RoutingPriority<envoy_api_enum_RoutingPriority>`
+    // the specified CircuitBreaker settings apply to.
+    RoutingPriority priority = 1;
+
+    // The maximum number of connections that Envoy will make to the upstream
+    // cluster. If not specified, the default is 1024.
+    google.protobuf.UInt32Value max_connections = 2;
+
+    // The maximum number of pending requests that Envoy will allow to the
+    // upstream cluster. If not specified, the default is 1024.
+    google.protobuf.UInt32Value max_pending_requests = 3;
+
+    // The maximum number of parallel requests that Envoy will make to the
+    // upstream cluster. If not specified, the default is 1024.
+    google.protobuf.UInt32Value max_requests = 4;
+
+    // The maximum number of parallel retries that Envoy will allow to the
+    // upstream cluster. If not specified, the default is 3.
+    google.protobuf.UInt32Value max_retries = 5;
+  }
+
+  // If multiple :ref:`Thresholds<envoy_api_msg_CircuitBreakers.Thresholds>`
+  // are defined with the same :ref:`RoutingPriority<envoy_api_enum_RoutingPriority>`,
+  // the first one in the list is used. If no Thresholds is defined for a given
+  // :ref:`RoutingPriority<envoy_api_enum_RoutingPriority>`, the default values
+  // are used.
+  repeated Thresholds thresholds = 1;
 }

--- a/api/filter/accesslog/accesslog.proto
+++ b/api/filter/accesslog/accesslog.proto
@@ -244,6 +244,48 @@ message HTTPAccessLogEntry {
   HTTPResponseProperties response = 4;
 }
 
+message AccessLog {
+  // The name of the access log implementation to instantiate. The name must
+  // match a statically registered access log. Current built-in loggers include:
+  // 1) "envoy.file_access_log"
+  string name = 1;
+
+  // Filter which is used to determine if the access log needs to be written.
+  AccessLogFilter filter = 2;
+
+  // Custom configuration that depends on the access log being instantiated. built-in configurations
+  // include:
+  // 1) "envoy.file_access_log": :ref:`FileAccessLog <envoy_api_msg_filter.accesslog.FileAccessLog>`
+  google.protobuf.Struct config = 3;
+}
+
+message AccessLogFilter {
+  oneof filter_specifier {
+    option (validate.required) = true;
+
+    // Status code filter.
+    StatusCodeFilter status_code_filter = 1;
+
+    // Duration filter.
+    DurationFilter duration_filter = 2;
+
+    // Not health check filter.
+    NotHealthCheckFilter not_health_check_filter = 3;
+
+    // Traceable filter.
+    TraceableFilter traceable_filter = 4;
+
+    // Runtime filter.
+    RuntimeFilter runtime_filter = 5;
+
+    // And filter.
+    AndFilter and_filter = 6;
+
+    // Or filter.
+    OrFilter or_filter = 7;
+  }
+}
+
 // Filter on an integer comparison.
 message ComparisonFilter {
   enum Op {
@@ -307,33 +349,6 @@ message AndFilter {
 // filter returns true immediately.
 message OrFilter {
   repeated AccessLogFilter filters = 2 [(validate.rules).repeated .min_items = 2];
-}
-
-message AccessLogFilter {
-  oneof filter_specifier {
-    option (validate.required) = true;
-
-    // Status code filter.
-    StatusCodeFilter status_code_filter = 1;
-
-    // Duration filter.
-    DurationFilter duration_filter = 2;
-
-    // Not health check filter.
-    NotHealthCheckFilter not_health_check_filter = 3;
-
-    // Traceable filter.
-    TraceableFilter traceable_filter = 4;
-
-    // Runtime filter.
-    RuntimeFilter runtime_filter = 5;
-
-    // And filter.
-    AndFilter and_filter = 6;
-
-    // Or filter.
-    OrFilter or_filter = 7;
-  }
 }
 
 // Custom configuration for an AccessLog that writes log entries directly to a file.
@@ -411,19 +426,4 @@ service AccessLogService {
   // expectation that it might be lossy.
   rpc StreamAccessLogs(stream StreamAccessLogsMessage) returns (StreamAccessLogsResponse) {
   }
-}
-
-message AccessLog {
-  // The name of the access log implementation to instantiate. The name must
-  // match a statically registered access log. Current built-in loggers include:
-  // 1) "envoy.file_access_log"
-  string name = 1;
-
-  // Filter which is used to determine if the access log needs to be written.
-  AccessLogFilter filter = 2;
-
-  // Custom configuration that depends on the access log being instantiated. built-in configurations
-  // include:
-  // 1) "envoy.file_access_log": :ref:`FileAccessLog <envoy_api_msg_filter.accesslog.FileAccessLog>`
-  google.protobuf.Struct config = 3;
 }

--- a/api/filter/network/http_connection_manager.proto
+++ b/api/filter/network/http_connection_manager.proto
@@ -17,50 +17,6 @@ import "validate/validate.proto";
 // [#protodoc-title: HTTP connection manager]
 // HTTP connection manager :ref:`configuration overview <config_http_conn_man>`.
 
-message Rds {
-  // Configuration source specifier for RDS.
-  ConfigSource config_source = 1 [(validate.rules).message.required = true];
-
-  // The name of the route configuration. This name will be passed to the RDS
-  // API. This allows an Envoy configuration with multiple HTTP listeners (and
-  // associated HTTP connection manager filters) to use different route
-  // configurations.
-  string route_config_name = 2 [(validate.rules).string.min_bytes = 1];
-}
-
-message HttpFilter {
-  // The name of the filter to instantiate. The name must match a supported
-  // filter. The built-in filters are:
-  //
-  // [#comment:TODO(mattklein123): Auto generate the following list]
-  // * :ref:`envoy.buffer <config_http_filters_buffer>`
-  // * :ref:`envoy.cors <config_http_filters_cors>`
-  // * :ref:`envoy.fault <config_http_filters_fault_injection>`
-  // * :ref:`envoy.http_dynamo_filter <config_http_filters_dynamo>`
-  // * :ref:`envoy.grpc_http1_bridge <config_http_filters_grpc_bridge>`
-  // * :ref:`envoy.grpc_json_transcoder <config_http_filters_grpc_json_transcoder>`
-  // * :ref:`envoy.grpc_web <config_http_filters_grpc_web>`
-  // * :ref:`envoy.health_check <config_http_filters_health_check>`
-  // * :ref:`envoy.lua <config_http_filters_lua>`
-  // * :ref:`envoy.rate_limit <config_http_filters_rate_limit>`
-  // * :ref:`envoy.router <config_http_filters_router>`
-  string name = 1 [(validate.rules).string.min_bytes = 1];
-
-  // Filter specific configuration which depends on the filter being
-  // instantiated. See the supported filters for further documentation.
-  google.protobuf.Struct config = 2;
-
-  // [#not-implemented-hide:]
-  // This is hidden as type has been deprecated and is no longer required.
-  message DeprecatedV1 {
-    string type = 1;
-  }
-
-  // [#not-implemented-hide:]
-  // This is hidden as type has been deprecated and is no longer required.
-  DeprecatedV1 deprecated_v1 = 3;
-}
-
 message HttpConnectionManager {
   enum CodecType {
     // For every new connection, the connection manager will determine which
@@ -221,4 +177,48 @@ message HttpConnectionManager {
   // :ref:`config_http_conn_man_headers_x-forwarded-client-cert` header, *Hash* is always set, and
   // *By* is always set when the client certificate presents the SAN value.
   SetCurrentClientCertDetails set_current_client_cert_details = 17;
+}
+
+message Rds {
+  // Configuration source specifier for RDS.
+  ConfigSource config_source = 1 [(validate.rules).message.required = true];
+
+  // The name of the route configuration. This name will be passed to the RDS
+  // API. This allows an Envoy configuration with multiple HTTP listeners (and
+  // associated HTTP connection manager filters) to use different route
+  // configurations.
+  string route_config_name = 2 [(validate.rules).string.min_bytes = 1];
+}
+
+message HttpFilter {
+  // The name of the filter to instantiate. The name must match a supported
+  // filter. The built-in filters are:
+  //
+  // [#comment:TODO(mattklein123): Auto generate the following list]
+  // * :ref:`envoy.buffer <config_http_filters_buffer>`
+  // * :ref:`envoy.cors <config_http_filters_cors>`
+  // * :ref:`envoy.fault <config_http_filters_fault_injection>`
+  // * :ref:`envoy.http_dynamo_filter <config_http_filters_dynamo>`
+  // * :ref:`envoy.grpc_http1_bridge <config_http_filters_grpc_bridge>`
+  // * :ref:`envoy.grpc_json_transcoder <config_http_filters_grpc_json_transcoder>`
+  // * :ref:`envoy.grpc_web <config_http_filters_grpc_web>`
+  // * :ref:`envoy.health_check <config_http_filters_health_check>`
+  // * :ref:`envoy.lua <config_http_filters_lua>`
+  // * :ref:`envoy.rate_limit <config_http_filters_rate_limit>`
+  // * :ref:`envoy.router <config_http_filters_router>`
+  string name = 1 [(validate.rules).string.min_bytes = 1];
+
+  // Filter specific configuration which depends on the filter being
+  // instantiated. See the supported filters for further documentation.
+  google.protobuf.Struct config = 2;
+
+  // [#not-implemented-hide:]
+  // This is hidden as type has been deprecated and is no longer required.
+  message DeprecatedV1 {
+    string type = 1;
+  }
+
+  // [#not-implemented-hide:]
+  // This is hidden as type has been deprecated and is no longer required.
+  DeprecatedV1 deprecated_v1 = 3;
 }

--- a/api/lds.proto
+++ b/api/lds.proto
@@ -32,6 +32,79 @@ service ListenerDiscoveryService {
   }
 }
 
+message Listener {
+  // The unique name by which this listener is known. If no name is provided,
+  // Envoy will allocate an internal UUID for the listener. If the listener is to be dynamically
+  // updated or removed via :ref:`LDS <config_listeners_lds>` a unique name must be provided.
+  // By default, the maximum length of a listener's name is limited to 60 characters. This limit can
+  // be increased by setting the :option:`--max-obj-name-len` command line argument to the desired
+  // value.
+  string name = 1;
+
+  // The address that the listener should listen on. In general, the address must be unique, though
+  // that is governed by the bind rules of the OS. E.g., multiple listeners can listen on port 0 on
+  // Linux as the actual port will be allocated by the OS.
+  Address address = 2 [(validate.rules).message.required = true];
+
+  // A list of filter chains to consider for this listener. The
+  // :ref:`FilterChain <envoy_api_msg_FilterChain>` with the most specific :ref:`FilterChainMatch
+  // <envoy_api_msg_FilterChainMatch>` criteria is used on a connection.
+  //
+  // .. attention::
+  //
+  //   In the current version, multiple filter chains are supported **only** so that SNI can be
+  //   configured. See the :ref:`FAQ entry <faq_how_to_setup_sni>` on how to configure SNI for more
+  //   information. When multiple filter chains are configured, each filter chain must have an
+  //   **identical** set of :ref:`filters <envoy_api_field_FilterChain.filters>`. If the filters
+  //   differ, the configuration will fail to load. In the future, this limitation will be relaxed
+  //   such that different filters can be used depending on which filter chain matches (based on SNI
+  //   or some other parameter).
+  repeated FilterChain filter_chains = 3 [(validate.rules).repeated .min_items = 1];
+
+  // If a connection is redirected using *iptables*, the port on which the proxy
+  // receives it might be different from the original destination address. When this flag is set to
+  // true, the listener hands off redirected connections to the listener associated with the
+  // original destination address. If there is no listener associated with the original destination
+  // address, the connection is handled by the listener that receives it. Defaults to false.
+  google.protobuf.BoolValue use_original_dst = 4;
+
+  // Soft limit on size of the listener’s new connection read and write buffers.
+  // If unspecified, an implementation defined default is applied (1MiB).
+  google.protobuf.UInt32Value per_connection_buffer_limit_bytes = 5;
+
+  // [#not-implemented-hide:] Listener metadata.
+  Metadata metadata = 6;
+
+  // [#not-implemented-hide:]
+  message DeprecatedV1 {
+    // Whether the listener should bind to the port. A listener that doesn’t
+    // bind can only receive connections redirected from other listeners that
+    // set use_original_dst parameter to true. Default is true.
+    //
+    // [V2-API-DIFF] This is deprecated in v2, all Listeners will bind to their
+    // port. An additional filter chain must be created for every original
+    // destination port this listener may redirect to in v2, with the original
+    // port specified in the FilterChainMatch destination_port field.
+    google.protobuf.BoolValue bind_to_port = 1;
+  }
+
+  // [#not-implemented-hide:]
+  DeprecatedV1 deprecated_v1 = 7;
+
+  enum DrainType {
+    // Drain in response to calling /healthcheck/fail admin endpoint (along with the health check
+    // filter), listener removal/modification, and hot restart.
+    DEFAULT = 0;
+    // Drain in response to listener removal/modification and hot restart. This setting does not
+    // include /healthcheck/fail. This setting may be desirable if Envoy is hosting both ingress
+    // and egress listeners.
+    MODIFY_ONLY = 1;
+  }
+
+  // The type of draining to perform at a listener-wide level.
+  DrainType drain_type = 8;
+}
+
 message Filter {
   // The name of the filter to instantiate. The name must match a supported
   // filter. The built-in filters are:
@@ -129,77 +202,4 @@ message FilterChain {
 
   // [#not-implemented-hide:] See base.TransportSocket description.
   TransportSocket transport_socket = 6;
-}
-
-message Listener {
-  // The unique name by which this listener is known. If no name is provided,
-  // Envoy will allocate an internal UUID for the listener. If the listener is to be dynamically
-  // updated or removed via :ref:`LDS <config_listeners_lds>` a unique name must be provided.
-  // By default, the maximum length of a listener's name is limited to 60 characters. This limit can
-  // be increased by setting the :option:`--max-obj-name-len` command line argument to the desired
-  // value.
-  string name = 1;
-
-  // The address that the listener should listen on. In general, the address must be unique, though
-  // that is governed by the bind rules of the OS. E.g., multiple listeners can listen on port 0 on
-  // Linux as the actual port will be allocated by the OS.
-  Address address = 2 [(validate.rules).message.required = true];
-
-  // A list of filter chains to consider for this listener. The
-  // :ref:`FilterChain <envoy_api_msg_FilterChain>` with the most specific :ref:`FilterChainMatch
-  // <envoy_api_msg_FilterChainMatch>` criteria is used on a connection.
-  //
-  // .. attention::
-  //
-  //   In the current version, multiple filter chains are supported **only** so that SNI can be
-  //   configured. See the :ref:`FAQ entry <faq_how_to_setup_sni>` on how to configure SNI for more
-  //   information. When multiple filter chains are configured, each filter chain must have an
-  //   **identical** set of :ref:`filters <envoy_api_field_FilterChain.filters>`. If the filters
-  //   differ, the configuration will fail to load. In the future, this limitation will be relaxed
-  //   such that different filters can be used depending on which filter chain matches (based on SNI
-  //   or some other parameter).
-  repeated FilterChain filter_chains = 3 [(validate.rules).repeated .min_items = 1];
-
-  // If a connection is redirected using *iptables*, the port on which the proxy
-  // receives it might be different from the original destination address. When this flag is set to
-  // true, the listener hands off redirected connections to the listener associated with the
-  // original destination address. If there is no listener associated with the original destination
-  // address, the connection is handled by the listener that receives it. Defaults to false.
-  google.protobuf.BoolValue use_original_dst = 4;
-
-  // Soft limit on size of the listener’s new connection read and write buffers.
-  // If unspecified, an implementation defined default is applied (1MiB).
-  google.protobuf.UInt32Value per_connection_buffer_limit_bytes = 5;
-
-  // [#not-implemented-hide:] Listener metadata.
-  Metadata metadata = 6;
-
-  // [#not-implemented-hide:]
-  message DeprecatedV1 {
-    // Whether the listener should bind to the port. A listener that doesn’t
-    // bind can only receive connections redirected from other listeners that
-    // set use_original_dst parameter to true. Default is true.
-    //
-    // [V2-API-DIFF] This is deprecated in v2, all Listeners will bind to their
-    // port. An additional filter chain must be created for every original
-    // destination port this listener may redirect to in v2, with the original
-    // port specified in the FilterChainMatch destination_port field.
-    google.protobuf.BoolValue bind_to_port = 1;
-  }
-
-  // [#not-implemented-hide:]
-  DeprecatedV1 deprecated_v1 = 7;
-
-  enum DrainType {
-    // Drain in response to calling /healthcheck/fail admin endpoint (along with the health check
-    // filter), listener removal/modification, and hot restart.
-    DEFAULT = 0;
-    // Drain in response to listener removal/modification and hot restart. This setting does not
-    // include /healthcheck/fail. This setting may be desirable if Envoy is hosting both ingress
-    // and egress listeners.
-    MODIFY_ONLY = 1;
-  }
-
-  // The type of draining to perform at a listener-wide level.
-  DrainType drain_type = 8;
 }

--- a/api/rds.proto
+++ b/api/rds.proto
@@ -31,6 +31,169 @@ service RouteDiscoveryService {
   }
 }
 
+// * Routing :ref:`architecture overview <arch_overview_http_routing>`
+// * HTTP :ref:`router filter <config_http_filters_router>`
+message RouteConfiguration {
+  // The name of the route configuration. For example, it might match
+  // :ref:`route_config_name <envoy_api_field_filter.network.Rds.route_config_name>` in
+  // :ref:`envoy_api_msg_filter.network.Rds`.
+  string name = 1;
+
+  // An array of virtual hosts that make up the route table.
+  repeated VirtualHost virtual_hosts = 2;
+
+  // Optionally specifies a list of HTTP headers that the connection manager
+  // will consider to be internal only. If they are found on external requests they will be cleaned
+  // prior to filter invocation. See :ref:`config_http_conn_man_headers_x-envoy-internal` for more
+  // information.
+  repeated string internal_only_headers = 3;
+
+  // Specifies a list of HTTP headers that should be added to each response that
+  // the connection manager encodes. Headers specified at this level are applied
+  // after headers from any enclosed :ref:`envoy_api_msg_VirtualHost` or
+  // :ref:`envoy_api_msg_RouteAction`.
+  repeated HeaderValueOption response_headers_to_add = 4;
+
+  // Specifies a list of HTTP headers that should be removed from each response
+  // that the connection manager encodes.
+  repeated string response_headers_to_remove = 5;
+
+  // Specifies a list of HTTP headers that should be added to each request
+  // routed by the HTTP connection manager. Headers specified at this level are
+  // applied after headers from any enclosed :ref:`envoy_api_msg_VirtualHost` or
+  // :ref:`envoy_api_msg_RouteAction`. For more information see the documentation on
+  // :ref:`custom request headers <config_http_conn_man_headers_custom_request_headers>`.
+  repeated HeaderValueOption request_headers_to_add = 6;
+
+  // An optional boolean that specifies whether the clusters that the route
+  // table refers to will be validated by the cluster manager. If set to true
+  // and a route refers to a non-existent cluster, the route table will not
+  // load. If set to false and a route refers to a non-existent cluster, the
+  // route table will load and the router filter will return a 404 if the route
+  // is selected at runtime. This setting defaults to true if the route table
+  // is statically defined via the :ref:`route_config
+  // <envoy_api_field_filter.network.HttpConnectionManager.route_config>` option. This setting
+  // default to false if the route table is loaded dynamically via the :ref:`rds
+  // <envoy_api_field_filter.network.HttpConnectionManager.rds>` option. Users
+  // may which to override the default behavior in certain cases (for example
+  // when using CDS with a static route table).
+  google.protobuf.BoolValue validate_clusters = 7;
+}
+
+// The top level element in the routing configuration is a virtual host. Each virtual host has
+// a logical name as well as a set of domains that get routed to it based on the incoming request's
+// host header. This allows a single listener to service multiple top level domain path trees. Once
+// a virtual host is selected based on the domain, the routes are processed in order to see which
+// upstream cluster to route to or whether to perform a redirect.
+message VirtualHost {
+  // The logical name of the virtual host. This is used when emitting certain
+  // statistics but is not relevant for routing.
+  string name = 1 [(validate.rules).string.min_bytes = 1];
+
+  // A list of domains (host/authority header) that will be matched to this
+  // virtual host. Wildcard hosts are supported in the form of “*.foo.com” or
+  // “*-bar.foo.com”.
+  //
+  // .. note::
+  //
+  //   The wildcard will not match the empty string.
+  //   e.g. “*-bar.foo.com” will match “baz-bar.foo.com” but not “-bar.foo.com”.
+  //   Additionally, a special entry “*” is allowed which will match any
+  //   host/authority header. Only a single virtual host in the entire route
+  //   configuration can match on “*”. A domain must be unique across all virtual
+  //   hosts or the config will fail to load.
+  repeated string domains = 2 [(validate.rules).repeated .min_items = 1];
+
+  // The list of routes that will be matched, in order, for incoming requests.
+  // The first route that matches will be used.
+  repeated Route routes = 3;
+
+  enum TlsRequirementType {
+    // No TLS requirement for the virtual host.
+    NONE = 0;
+
+    // External requests must use TLS. If a request is external and it is not
+    // using TLS, a 301 redirect will be sent telling the client to use HTTPS.
+    EXTERNAL_ONLY = 1;
+
+    // All requests must use TLS. If a request is not using TLS, a 301 redirect
+    // will be sent telling the client to use HTTPS.
+    ALL = 2;
+  }
+
+  // Specifies the type of TLS enforcement the virtual host expects. If this option is not
+  // specified, there is no TLS requirement for the virtual host.
+  TlsRequirementType require_tls = 4;
+
+  // A list of virtual clusters defined for this virtual host. Virtual clusters
+  // are used for additional statistics gathering.
+  repeated VirtualCluster virtual_clusters = 5;
+
+  // Specifies a set of rate limit configurations that will be applied to the
+  // virtual host.
+  repeated RateLimit rate_limits = 6;
+
+  // Specifies a list of HTTP headers that should be added to each request
+  // handled by this virtual host. Headers specified at this level are applied
+  // after headers from enclosed :ref:`envoy_api_msg_RouteAction` and before headers from the
+  // enclosing :ref:`envoy_api_msg_RouteConfiguration`. For more information see the documentation
+  // on :ref:`custom request headers <config_http_conn_man_headers_custom_request_headers>`.
+  repeated HeaderValueOption request_headers_to_add = 7;
+
+  // Specifies a list of HTTP headers that should be added to each response
+  // handled by this virtual host. Headers specified at this level are applied
+  // after headers from enclosed :ref:`envoy_api_msg_RouteAction` and before headers from the
+  // enclosing :ref:`envoy_api_msg_RouteConfiguration`.
+  repeated HeaderValueOption response_headers_to_add = 10;
+
+  // Specifies a list of HTTP headers that should be removed from each response
+  // handle by this virtual host.
+  repeated string response_headers_to_remove = 11;
+
+  // Indicates that the virtual host has a CORS policy.
+  CorsPolicy cors = 8;
+
+  // [#not-implemented-hide:]
+  // Return a 401/403 when auth checks fail.
+  AuthAction auth = 9;
+}
+
+// A route is both a specification of how to match a request as well as an indication of what to do
+// next (e.g., redirect, forward, rewrite, etc.).
+//
+// .. attention::
+//
+//   Envoy supports routing on HTTP method via :ref:`header matching
+//   <envoy_api_msg_HeaderMatcher>`.
+message Route {
+  // Route matching parameters.
+  RouteMatch match = 1 [(validate.rules).message.required = true];
+
+  oneof action {
+    option (validate.required) = true;
+
+    // Route request to some upstream cluster.
+    RouteAction route = 2;
+
+    // Return a redirect.
+    RedirectAction redirect = 3;
+  }
+
+  // The Metadata field can be used to provide additional information
+  // about the route. It can be used for configuration, stats, and logging.
+  // The metadata should go under the filter namespace that will need it.
+  // For instance, if the metadata is intended for the Router filter,
+  // the filter name should be specified as *envoy.router*.
+  Metadata metadata = 4;
+
+  // Decorator for the matched route.
+  Decorator decorator = 5;
+
+  // [#not-implemented-hide:]
+  // Return a 401/403 when auth checks fail.
+  AuthAction auth = 6;
+}
+
 // Compared to the :ref:`cluster <envoy_api_field_RouteAction.cluster>` field that specifies a
 // single upstream cluster as the target of a request, the :ref:`weighted_clusters
 // <envoy_api_field_RouteAction.weighted_clusters>` option allows for specification of
@@ -424,42 +587,6 @@ message Decorator {
   string operation = 1 [(validate.rules).string.min_bytes = 1];
 }
 
-// A route is both a specification of how to match a request as well as an indication of what to do
-// next (e.g., redirect, forward, rewrite, etc.).
-//
-// .. attention::
-//
-//   Envoy supports routing on HTTP method via :ref:`header matching
-//   <envoy_api_msg_HeaderMatcher>`.
-message Route {
-  // Route matching parameters.
-  RouteMatch match = 1 [(validate.rules).message.required = true];
-
-  oneof action {
-    option (validate.required) = true;
-
-    // Route request to some upstream cluster.
-    RouteAction route = 2;
-
-    // Return a redirect.
-    RedirectAction redirect = 3;
-  }
-
-  // The Metadata field can be used to provide additional information
-  // about the route. It can be used for configuration, stats, and logging.
-  // The metadata should go under the filter namespace that will need it.
-  // For instance, if the metadata is intended for the Router filter,
-  // the filter name should be specified as *envoy.router*.
-  Metadata metadata = 4;
-
-  // Decorator for the matched route.
-  Decorator decorator = 5;
-
-  // [#not-implemented-hide:]
-  // Return a 401/403 when auth checks fail.
-  AuthAction auth = 6;
-}
-
 // A virtual cluster is a way of specifying a regex matching rule against
 // certain important endpoints such that statistics are generated explicitly for
 // the matched requests. The reason this is useful is that when doing
@@ -669,131 +796,4 @@ message HeaderMatcher {
   // * The regex *\d{3}* does not match the value *1234*
   // * The regex *\d{3}* does not match the value *123.456*
   google.protobuf.BoolValue regex = 3;
-}
-
-// The top level element in the routing configuration is a virtual host. Each virtual host has
-// a logical name as well as a set of domains that get routed to it based on the incoming request's
-// host header. This allows a single listener to service multiple top level domain path trees. Once
-// a virtual host is selected based on the domain, the routes are processed in order to see which
-// upstream cluster to route to or whether to perform a redirect.
-message VirtualHost {
-  // The logical name of the virtual host. This is used when emitting certain
-  // statistics but is not relevant for routing.
-  string name = 1 [(validate.rules).string.min_bytes = 1];
-
-  // A list of domains (host/authority header) that will be matched to this
-  // virtual host. Wildcard hosts are supported in the form of “*.foo.com” or
-  // “*-bar.foo.com”.
-  //
-  // .. note::
-  //
-  //   The wildcard will not match the empty string.
-  //   e.g. “*-bar.foo.com” will match “baz-bar.foo.com” but not “-bar.foo.com”.
-  //   Additionally, a special entry “*” is allowed which will match any
-  //   host/authority header. Only a single virtual host in the entire route
-  //   configuration can match on “*”. A domain must be unique across all virtual
-  //   hosts or the config will fail to load.
-  repeated string domains = 2 [(validate.rules).repeated .min_items = 1];
-
-  // The list of routes that will be matched, in order, for incoming requests.
-  // The first route that matches will be used.
-  repeated Route routes = 3;
-
-  enum TlsRequirementType {
-    // No TLS requirement for the virtual host.
-    NONE = 0;
-
-    // External requests must use TLS. If a request is external and it is not
-    // using TLS, a 301 redirect will be sent telling the client to use HTTPS.
-    EXTERNAL_ONLY = 1;
-
-    // All requests must use TLS. If a request is not using TLS, a 301 redirect
-    // will be sent telling the client to use HTTPS.
-    ALL = 2;
-  }
-
-  // Specifies the type of TLS enforcement the virtual host expects. If this option is not
-  // specified, there is no TLS requirement for the virtual host.
-  TlsRequirementType require_tls = 4;
-
-  // A list of virtual clusters defined for this virtual host. Virtual clusters
-  // are used for additional statistics gathering.
-  repeated VirtualCluster virtual_clusters = 5;
-
-  // Specifies a set of rate limit configurations that will be applied to the
-  // virtual host.
-  repeated RateLimit rate_limits = 6;
-
-  // Specifies a list of HTTP headers that should be added to each request
-  // handled by this virtual host. Headers specified at this level are applied
-  // after headers from enclosed :ref:`envoy_api_msg_RouteAction` and before headers from the
-  // enclosing :ref:`envoy_api_msg_RouteConfiguration`. For more information see the documentation
-  // on :ref:`custom request headers <config_http_conn_man_headers_custom_request_headers>`.
-  repeated HeaderValueOption request_headers_to_add = 7;
-
-  // Specifies a list of HTTP headers that should be added to each response
-  // handled by this virtual host. Headers specified at this level are applied
-  // after headers from enclosed :ref:`envoy_api_msg_RouteAction` and before headers from the
-  // enclosing :ref:`envoy_api_msg_RouteConfiguration`.
-  repeated HeaderValueOption response_headers_to_add = 10;
-
-  // Specifies a list of HTTP headers that should be removed from each response
-  // handle by this virtual host.
-  repeated string response_headers_to_remove = 11;
-
-  // Indicates that the virtual host has a CORS policy.
-  CorsPolicy cors = 8;
-
-  // [#not-implemented-hide:]
-  // Return a 401/403 when auth checks fail.
-  AuthAction auth = 9;
-}
-
-// * Routing :ref:`architecture overview <arch_overview_http_routing>`
-// * HTTP :ref:`router filter <config_http_filters_router>`
-message RouteConfiguration {
-  // The name of the route configuration. For example, it might match
-  // :ref:`route_config_name <envoy_api_field_filter.network.Rds.route_config_name>` in
-  // :ref:`envoy_api_msg_filter.network.Rds`.
-  string name = 1;
-
-  // An array of virtual hosts that make up the route table.
-  repeated VirtualHost virtual_hosts = 2;
-
-  // Optionally specifies a list of HTTP headers that the connection manager
-  // will consider to be internal only. If they are found on external requests they will be cleaned
-  // prior to filter invocation. See :ref:`config_http_conn_man_headers_x-envoy-internal` for more
-  // information.
-  repeated string internal_only_headers = 3;
-
-  // Specifies a list of HTTP headers that should be added to each response that
-  // the connection manager encodes. Headers specified at this level are applied
-  // after headers from any enclosed :ref:`envoy_api_msg_VirtualHost` or
-  // :ref:`envoy_api_msg_RouteAction`.
-  repeated HeaderValueOption response_headers_to_add = 4;
-
-  // Specifies a list of HTTP headers that should be removed from each response
-  // that the connection manager encodes.
-  repeated string response_headers_to_remove = 5;
-
-  // Specifies a list of HTTP headers that should be added to each request
-  // routed by the HTTP connection manager. Headers specified at this level are
-  // applied after headers from any enclosed :ref:`envoy_api_msg_VirtualHost` or
-  // :ref:`envoy_api_msg_RouteAction`. For more information see the documentation on
-  // :ref:`custom request headers <config_http_conn_man_headers_custom_request_headers>`.
-  repeated HeaderValueOption request_headers_to_add = 6;
-
-  // An optional boolean that specifies whether the clusters that the route
-  // table refers to will be validated by the cluster manager. If set to true
-  // and a route refers to a non-existent cluster, the route table will not
-  // load. If set to false and a route refers to a non-existent cluster, the
-  // route table will load and the router filter will return a 404 if the route
-  // is selected at runtime. This setting defaults to true if the route table
-  // is statically defined via the :ref:`route_config
-  // <envoy_api_field_filter.network.HttpConnectionManager.route_config>` option. This setting
-  // default to false if the route table is loaded dynamically via the :ref:`rds
-  // <envoy_api_field_filter.network.HttpConnectionManager.rds>` option. Users
-  // may which to override the default behavior in certain cases (for example
-  // when using CDS with a static route table).
-  google.protobuf.BoolValue validate_clusters = 7;
 }


### PR DESCRIPTION
This is code movement only and no other changes. There should be
no namespace changes or effects to consumers.

Signed-off-by: Matt Klein <mklein@lyft.com>