### PR TITLE
docs: add version info docs for /clusters admin endpoint

### DIFF
--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -9,6 +9,7 @@ Version history
 * admin: added :ref:`JSON output <operations_admin_interface_stats>` for stats admin endpoint.
 * admin: added basic :ref:`Prometheus output <operations_admin_interface_stats>` for stats admin
   endpoint. Histograms are not currently output.
+* admin: added ``version_info`` to the :ref:`/clusters admin endpoint<operations_admin_interface_clusters>`.
 * config: the :ref:`v2 API <config_overview_v2>` is now considered production ready.
 * config: added :option:`--v2-config-only` CLI flag.
 * cors: added :ref:`CORS filter <config_http_filters_cors>`.

--- a/docs/root/operations/admin.rst
+++ b/docs/root/operations/admin.rst
@@ -18,6 +18,8 @@ modify different aspects of the server:
   List out all loaded TLS certificates, including file name, serial number, and days until
   expiration.
 
+.. _operations_admin_interface_clusters:
+
 .. http:get:: /clusters
 
   List out all configured :ref:`cluster manager <arch_overview_cluster_manager>` clusters. This

--- a/docs/root/operations/admin.rst
+++ b/docs/root/operations/admin.rst
@@ -24,6 +24,12 @@ modify different aspects of the server:
   information includes all discovered upstream hosts in each cluster along with per host statistics.
   This is useful for debugging service discovery issues.
 
+  Cluster manager information
+    - ``version_info`` string -- the version info string of the last loaded
+      :ref:`CDS<config_cluster_manager_cds>` update.
+      If envoy does not have :ref:`CDS<config_cluster_manager_cds>` setup, the
+      output will read ``version_info::static``.
+
   Cluster wide information
     - :ref:`circuit breakers<config_cluster_manager_cluster_circuit_breakers>` settings for all priority settings.
 


### PR DESCRIPTION
Signed-off-by: Jose Nino <jnino@lyft.com>

Add information about the version info string in the `/clusters` admin endpoint.