### PR TITLE
address: relax UDP constraint on SocketAddress.

### DIFF
--- a/api/address.proto
+++ b/api/address.proto
@@ -20,7 +20,7 @@ message SocketAddress {
     // [#not-implemented-hide:]
     UDP = 1;
   }
-  Protocol protocol = 1 [(validate.rules).enum = {in: [0]}];
+  Protocol protocol = 1;
   // The address for this socket. :ref:`Listeners <config_listeners>` will bind
   // to the address or outbound connections will be made. An empty address
   // implies a bind to 0.0.0.0 or ::. It's still possible to distinguish on an


### PR DESCRIPTION
statsd can send to UDP addresses.

Signed-off-by: Harvey Tuch <htuch@google.com>