### PR TITLE
Removing extra whitespace from rst / md

### DIFF
--- a/API_OVERVIEW.md
+++ b/API_OVERVIEW.md
@@ -98,7 +98,7 @@ In addition to the above APIs, an aggregation API will be provided to allow for
 fine grained control over the sequencing of API updates across discovery
 services:
 
-* [Aggregated Discovery Service (ADS)](api/discovery.proto). See 
+* [Aggregated Discovery Service (ADS)](api/discovery.proto). See
   the [ADS overview](https://www.envoyproxy.io/docs/envoy/latest/configuration/overview/v2_overview#aggregated-discovery-service).
 
 A protocol description for the xDS APIs is provided [here](XDS_PROTOCOL.md).

--- a/api/filter/README.md
+++ b/api/filter/README.md
@@ -6,13 +6,13 @@ setting the `"deprecated_v1"` field to true in the filter's
 configuration. For example,
 
 ```json
-{ 
+{
  "name": "envoy.rate_limit",
-  "config": { 
+  "config": {
     "deprecated_v1": true,
-     "value": { 
+     "value": {
        "domain": "some_domain",
-        "timeout_ms": 500 
+        "timeout_ms": 500
        }
     }
  }

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,17 +8,17 @@ The output can be found in `generated/docs`.
 
 # How the Envoy website and docs are updated
 
-The Envoy website, and docs are automatically built, and pushed on every commit 
-to master. This process is handled by Travis CI with the 
+The Envoy website, and docs are automatically built, and pushed on every commit
+to master. This process is handled by Travis CI with the
 [`publish.sh`](https://github.com/envoyproxy/envoy/blob/master/docs/publish.sh) script.
 
-In order to have this automatic process there is an encrypted ssh key at the root 
-of the envoy repo (`.publishdocskey.enc`). This key was encrypted with Travis CLI 
+In order to have this automatic process there is an encrypted ssh key at the root
+of the envoy repo (`.publishdocskey.enc`). This key was encrypted with Travis CLI
 and can only be decrypted by commits initiated in the Envoy repo, not PRs that are
-submitted from forks. This is the case because only PRs initiated in the Envoy 
-repo have access to the secure environment variables (`encrypted_b1a4cc52fa4a_iv`, 
+submitted from forks. This is the case because only PRs initiated in the Envoy
+repo have access to the secure environment variables (`encrypted_b1a4cc52fa4a_iv`,
 `encrypted_b1a4cc52fa4a_key`) [used to decrypt the key.](https://docs.travis-ci.com/user/pull-requests#Pull-Requests-and-Security-Restrictions)
 
-The key only has write access to the Envoy repo. If the key, or the variables 
-used to decrypt it are ever compromised, delete the key immediately from the 
+The key only has write access to the Envoy repo. If the key, or the variables
+used to decrypt it are ever compromised, delete the key immediately from the
 Envoy repo in `Settings > Deploy keys`.

--- a/docs/root/api-v1/cluster_manager/cluster.rst
+++ b/docs/root/api-v1/cluster_manager/cluster.rst
@@ -57,7 +57,7 @@ per_connection_buffer_limit_bytes
 lb_type
   *(required, string)* The :ref:`load balancer type <arch_overview_load_balancing_types>` to use
   when picking a host in the cluster. Possible options are *round_robin*, *least_request*,
-  *ring_hash*, *random*, and *original_dst_lb*.  Note that :ref:`*original_dst_lb*
+  *ring_hash*, *random*, and *original_dst_lb*. Note that :ref:`*original_dst_lb*
   <arch_overview_load_balancing_types_original_destination>` must be used with clusters of type
   :ref:`*original_dst* <arch_overview_service_discovery_types_original_destination>`, and may not be
   used with any other cluster type.

--- a/docs/root/api-v1/listeners/listeners.rst
+++ b/docs/root/api-v1/listeners/listeners.rst
@@ -214,7 +214,7 @@ session_ticket_key_paths
   sessions via tickets, but it will use an internally-generated and managed key, so sessions cannot
   be resumed across hot restarts or on different hosts.
 
-  Each keyfile must contain exactly 80 bytes of cryptographically-secure random data.  For example,
+  Each keyfile must contain exactly 80 bytes of cryptographically-secure random data. For example,
   the output of ``openssl rand 80``.
 
   .. attention::

--- a/docs/root/api-v1/network_filters/http_conn_man.rst
+++ b/docs/root/api-v1/network_filters/http_conn_man.rst
@@ -131,7 +131,7 @@ http2_settings
     size now, so it's also the minimum.
 
     This field also acts as a soft limit on the number of bytes Envoy will buffer per-stream in the
-    HTTP/2 codec buffers.  Once the buffer reaches this pointer, watermark callbacks will fire to
+    HTTP/2 codec buffers. Once the buffer reaches this pointer, watermark callbacks will fire to
     stop the flow of data to the codec buffers.
 
   initial_connection_window_size

--- a/docs/root/api-v1/network_filters/tcp_proxy_filter.rst
+++ b/docs/root/api-v1/network_filters/tcp_proxy_filter.rst
@@ -73,7 +73,7 @@ destination_ip_list
   contained in at least one of the specified subnets.
   If the parameter is not specified or the list is empty, the destination IP address is ignored.
   The destination IP address of the downstream connection might be different from the addresses
-  on which the proxy is listening if the connection has been redirected.  Example:
+  on which the proxy is listening if the connection has been redirected. Example:
 
  .. code-block:: json
 
@@ -117,7 +117,7 @@ source_ports
   *(optional, string)* An optional string containing a comma-separated list of port numbers or
   ranges. The criteria is satisfied if the source port of the downstream connection is contained
   in at least one of the specified ranges. If the parameter is not specified, the source port is
-  ignored.  Example:
+  ignored. Example:
 
  .. code-block:: json
 

--- a/docs/root/api-v1/route_config/route.rst
+++ b/docs/root/api-v1/route_config/route.rst
@@ -473,7 +473,7 @@ Opaque Config
 Additional configuration can be provided to filters through the "Opaque Config" mechanism. A
 list of properties are specified in the route config. The configuration is uninterpreted
 by envoy and can be accessed within a user-defined filter. The configuration is a generic
-string map.  Nested objects are not supported.
+string map. Nested objects are not supported.
 
 .. code-block:: json
 

--- a/docs/root/api-v1/route_config/vhost.rst
+++ b/docs/root/api-v1/route_config/vhost.rst
@@ -31,9 +31,9 @@ domains
   *(required, array)* A list of domains (host/authority header) that will be matched to this
   virtual host. Wildcard hosts are supported in the form of "\*.foo.com" or "\*-bar.foo.com".
   Note that the wildcard will not match the empty string. e.g. "\*-bar.foo.com" will match
-  "baz-bar.foo.com" but not "-bar.foo.com".  Additionally, a special entry "\*" is allowed
-  which will match any host/authority header.  Only a single virtual host in the entire route
-  configuration can match on "\*".  A domain must be unique across all virtual hosts or the config
+  "baz-bar.foo.com" but not "-bar.foo.com". Additionally, a special entry "\*" is allowed
+  which will match any host/authority header. Only a single virtual host in the entire route
+  configuration can match on "\*". A domain must be unique across all virtual hosts or the config
   will fail to load.
 
 :ref:`routes <config_http_conn_man_route_table_route>`

--- a/docs/root/configuration/access_log.rst
+++ b/docs/root/configuration/access_log.rst
@@ -23,8 +23,8 @@ has to specified as part of the format string.
 See the :ref:`default format <config_access_log_default_format>` for an example.
 Note that the access log line will contain a '-' character for every not set/empty value.
 
-The same format strings are used by different types of access logs (such as HTTP and TCP).  Some
-fields may have slightly different meanings, depending on what type of log it is.  Differences
+The same format strings are used by different types of access logs (such as HTTP and TCP). Some
+fields may have slightly different meanings, depending on what type of log it is. Differences
 are noted.
 
 The following command operators are supported:
@@ -74,7 +74,7 @@ The following command operators are supported:
 
 %RESPONSE_FLAGS%
   Additional details about the response or connection, if any. For TCP connections, the response codes mentioned in
-  the descriptions do not apply.  Possible values are:
+  the descriptions do not apply. Possible values are:
 
   HTTP and TCP
     * **UH**: No healthy upstream hosts in upstream cluster in addition to 503 response code.

--- a/docs/root/configuration/cluster_manager/cluster_runtime.rst
+++ b/docs/root/configuration/cluster_manager/cluster_runtime.rst
@@ -29,7 +29,7 @@ Outlier detection
 -----------------
 
 See the outlier detection :ref:`architecture overview <arch_overview_outlier_detection>` for more
-information on outlier detection. The runtime parameters supported by outlier detection are the 
+information on outlier detection. The runtime parameters supported by outlier detection are the
 same as the :ref:`static configuration parameters <config_cluster_manager_cluster_outlier_detection>`, namely:
 
 outlier_detection.consecutive_5xx

--- a/docs/root/configuration/http_filters/router_filter.rst
+++ b/docs/root/configuration/http_filters/router_filter.rst
@@ -119,7 +119,7 @@ Setting this header on egress requests will cause Envoy to attempt to retry fail
 retries defaults to 1, and can be controlled by
 :ref:`x-envoy-max-retries <config_http_filters_router_x-envoy-max-retries>`
 header or the :ref:`route config retry policy <config_http_conn_man_route_table_route_retry>`).
-gRPC retries are currently only supported for gRPC status codes in response headers.  gRPC status codes in
+gRPC retries are currently only supported for gRPC status codes in response headers. gRPC status codes in
 trailers will not trigger retry logic. One or more policies can be specified  using a ',' delimited
 list. The supported policies are:
 

--- a/docs/root/configuration/overview/v1_overview.rst
+++ b/docs/root/configuration/overview/v1_overview.rst
@@ -9,7 +9,7 @@ Overview (v1 API)
   and eventually removed completely. If you are new to Envoy please consider starting with the
   :ref:`v2 configuration/API <config_overview_v2>`.
 
-The Envoy configuration format is written in JSON and is validated against a JSON schema.  The
+The Envoy configuration format is written in JSON and is validated against a JSON schema. The
 schema can be found in :repo:`source/common/json/config_schemas.cc`. The main configuration for the
 server is contained within the listeners and cluster manager sections. The other top level elements
 specify miscellaneous configuration.

--- a/docs/root/configuration/overview/v2_overview.rst
+++ b/docs/root/configuration/overview/v2_overview.rst
@@ -46,7 +46,7 @@ debug experience when configuration parsing fails.
 
 The :ref:`Bootstrap <envoy_api_msg_Bootstrap>` message is the root of the
 configuration. A key concept in the :ref:`Bootstrap <envoy_api_msg_Bootstrap>`
-message is the distinction between static and dynamic resouces.  Resources such
+message is the distinction between static and dynamic resouces. Resources such
 as a :ref:`Listener <envoy_api_msg_Listener>` or :ref:`Cluster
 <envoy_api_msg_Cluster>` may be supplied either statically in
 :ref:`static_resources <envoy_api_field_Bootstrap.static_resources>` or have
@@ -292,7 +292,7 @@ Management server
 -----------------
 
 A v2 xDS management server will implement the below endpoints as required for
-gRPC and/or REST serving.  In both streaming gRPC and
+gRPC and/or REST serving. In both streaming gRPC and
 REST-JSON cases, a :ref:`DiscoveryRequest <envoy_api_msg_DiscoveryRequest>` is sent and a
 :ref:`DiscoveryResponse <envoy_api_msg_DiscoveryResponse>` received following the
 `xDS protocol <https://github.com/envoyproxy/data-plane-api/blob/master/XDS_PROTOCOL.md>`_.
@@ -473,7 +473,7 @@ server would deliver the CDS, EDS and then RDS updates on a single stream.
 ADS is only available for gRPC streaming (not REST) and is described more fully
 in `this
 <https://github.com/envoyproxy/data-plane-api/blob/master/XDS_PROTOCOL.md#aggregated-discovery-services-ads>`_
-document.  The gRPC endpoint is:
+document. The gRPC endpoint is:
 
 .. http:post:: /envoy.api.v2.AggregatedDiscoveryService/StreamAggregatedResources
 

--- a/docs/root/configuration/runtime.rst
+++ b/docs/root/configuration/runtime.rst
@@ -62,7 +62,7 @@ There are two steps to update any runtime value. First, create a hard copy of th
 tree and update the desired runtime values. Second, atomically swap the symbolic link root from the
 old tree to the new runtime tree, using the equivalent of the following command:
 
-..  code-block:: console
+.. code-block:: console
 
   /srv/runtime:~$ ln -s /srv/runtime/v2 new && mv -Tf new current
 

--- a/docs/root/install/sandboxes/front_proxy.rst
+++ b/docs/root/install/sandboxes/front_proxy.rst
@@ -55,9 +55,9 @@ or ``git clone https://github.com/envoyproxy/envoy.git``::
     $ docker-compose ps
             Name                       Command               State      Ports
     -------------------------------------------------------------------------------------------------------------
-    example_service1_1      /bin/sh -c /usr/local/bin/ ...    Up       80/tcp
-    example_service2_1      /bin/sh -c /usr/local/bin/ ...    Up       80/tcp
-    example_front-envoy_1   /bin/sh -c /usr/local/bin/ ...    Up       0.0.0.0:8000->80/tcp, 0.0.0.0:8001->8001/tcp
+    example_service1_1      /bin/sh -c /usr/local/bin/ ... Up       80/tcp
+    example_service2_1      /bin/sh -c /usr/local/bin/ ... Up       80/tcp
+    example_front-envoy_1   /bin/sh -c /usr/local/bin/ ... Up       0.0.0.0:8000->80/tcp, 0.0.0.0:8001->8001/tcp
 
 **Step 5: Test Envoy's routing capabilities**
 

--- a/docs/root/install/sandboxes/front_proxy.rst
+++ b/docs/root/install/sandboxes/front_proxy.rst
@@ -55,9 +55,9 @@ or ``git clone https://github.com/envoyproxy/envoy.git``::
     $ docker-compose ps
             Name                       Command               State      Ports
     -------------------------------------------------------------------------------------------------------------
-    example_service1_1      /bin/sh -c /usr/local/bin/ ... Up       80/tcp
-    example_service2_1      /bin/sh -c /usr/local/bin/ ... Up       80/tcp
-    example_front-envoy_1   /bin/sh -c /usr/local/bin/ ... Up       0.0.0.0:8000->80/tcp, 0.0.0.0:8001->8001/tcp
+    example_service1_1      /bin/sh -c /usr/local/bin/ ...    Up       80/tcp
+    example_service2_1      /bin/sh -c /usr/local/bin/ ...    Up       80/tcp
+    example_front-envoy_1   /bin/sh -c /usr/local/bin/ ...    Up       0.0.0.0:8000->80/tcp, 0.0.0.0:8001->8001/tcp
 
 **Step 5: Test Envoy's routing capabilities**
 

--- a/docs/root/install/sandboxes/jaeger_tracing.rst
+++ b/docs/root/install/sandboxes/jaeger_tracing.rst
@@ -6,7 +6,7 @@ Jaeger Tracing
 The Jaeger tracing sandbox demonstrates Envoy's :ref:`request tracing <arch_overview_tracing>`
 capabilities using `Jaeger <https://uber.github.io/jaeger/>`_ as the tracing provider. This sandbox
 is very similar to the front proxy architecture described above, with one difference:
-service1 makes an API call to service2 before returning a response. 
+service1 makes an API call to service2 before returning a response.
 The three containers will be deployed inside a virtual network called ``envoymesh``.
 
 All incoming requests are routed via the front envoy, which is acting as a reverse proxy
@@ -46,9 +46,9 @@ To build this sandbox example, and start the example apps run the following comm
     $ docker-compose ps
             Name                       Command               State      Ports
     -------------------------------------------------------------------------------------------------------------
-    jaegertracing_service1_1      /bin/sh -c /usr/local/bin/ ...    Up       80/tcp
-    jaegertracing_service2_1      /bin/sh -c /usr/local/bin/ ...    Up       80/tcp
-    jaegertracing_front-envoy_1   /bin/sh -c /usr/local/bin/ ...    Up       0.0.0.0:8000->80/tcp, 0.0.0.0:8001->8001/tcp
+    jaegertracing_service1_1      /bin/sh -c /usr/local/bin/ ... Up       80/tcp
+    jaegertracing_service2_1      /bin/sh -c /usr/local/bin/ ... Up       80/tcp
+    jaegertracing_front-envoy_1   /bin/sh -c /usr/local/bin/ ... Up       0.0.0.0:8000->80/tcp, 0.0.0.0:8001->8001/tcp
 
 **Step 2: Generate some load**
 

--- a/docs/root/install/sandboxes/jaeger_tracing.rst
+++ b/docs/root/install/sandboxes/jaeger_tracing.rst
@@ -46,9 +46,9 @@ To build this sandbox example, and start the example apps run the following comm
     $ docker-compose ps
             Name                       Command               State      Ports
     -------------------------------------------------------------------------------------------------------------
-    jaegertracing_service1_1      /bin/sh -c /usr/local/bin/ ... Up       80/tcp
-    jaegertracing_service2_1      /bin/sh -c /usr/local/bin/ ... Up       80/tcp
-    jaegertracing_front-envoy_1   /bin/sh -c /usr/local/bin/ ... Up       0.0.0.0:8000->80/tcp, 0.0.0.0:8001->8001/tcp
+    jaegertracing_service1_1      /bin/sh -c /usr/local/bin/ ...    Up       80/tcp
+    jaegertracing_service2_1      /bin/sh -c /usr/local/bin/ ...    Up       80/tcp
+    jaegertracing_front-envoy_1   /bin/sh -c /usr/local/bin/ ...    Up       0.0.0.0:8000->80/tcp, 0.0.0.0:8001->8001/tcp
 
 **Step 2: Generate some load**
 

--- a/docs/root/install/sandboxes/zipkin_tracing.rst
+++ b/docs/root/install/sandboxes/zipkin_tracing.rst
@@ -46,9 +46,9 @@ To build this sandbox example, and start the example apps run the following comm
     $ docker-compose ps
             Name                       Command               State      Ports
     -------------------------------------------------------------------------------------------------------------
-    zipkintracing_service1_1      /bin/sh -c /usr/local/bin/ ... Up       80/tcp
-    zipkintracing_service2_1      /bin/sh -c /usr/local/bin/ ... Up       80/tcp
-    zipkintracing_front-envoy_1   /bin/sh -c /usr/local/bin/ ... Up       0.0.0.0:8000->80/tcp, 0.0.0.0:8001->8001/tcp
+    zipkintracing_service1_1      /bin/sh -c /usr/local/bin/ ...    Up       80/tcp
+    zipkintracing_service2_1      /bin/sh -c /usr/local/bin/ ...    Up       80/tcp
+    zipkintracing_front-envoy_1   /bin/sh -c /usr/local/bin/ ...    Up       0.0.0.0:8000->80/tcp, 0.0.0.0:8001->8001/tcp
 
 **Step 2: Generate some load**
 

--- a/docs/root/install/sandboxes/zipkin_tracing.rst
+++ b/docs/root/install/sandboxes/zipkin_tracing.rst
@@ -6,7 +6,7 @@ Zipkin Tracing
 The Zipkin tracing sandbox demonstrates Envoy's :ref:`request tracing <arch_overview_tracing>`
 capabilities using `Zipkin <http://zipkin.io/>`_ as the tracing provider. This sandbox
 is very similar to the front proxy architecture described above, with one difference:
-service1 makes an API call to service2 before returning a response. 
+service1 makes an API call to service2 before returning a response.
 The three containers will be deployed inside a virtual network called ``envoymesh``.
 
 All incoming requests are routed via the front envoy, which is acting as a reverse proxy
@@ -46,9 +46,9 @@ To build this sandbox example, and start the example apps run the following comm
     $ docker-compose ps
             Name                       Command               State      Ports
     -------------------------------------------------------------------------------------------------------------
-    zipkintracing_service1_1      /bin/sh -c /usr/local/bin/ ...    Up       80/tcp
-    zipkintracing_service2_1      /bin/sh -c /usr/local/bin/ ...    Up       80/tcp
-    zipkintracing_front-envoy_1   /bin/sh -c /usr/local/bin/ ...    Up       0.0.0.0:8000->80/tcp, 0.0.0.0:8001->8001/tcp
+    zipkintracing_service1_1      /bin/sh -c /usr/local/bin/ ... Up       80/tcp
+    zipkintracing_service2_1      /bin/sh -c /usr/local/bin/ ... Up       80/tcp
+    zipkintracing_front-envoy_1   /bin/sh -c /usr/local/bin/ ... Up       0.0.0.0:8000->80/tcp, 0.0.0.0:8001->8001/tcp
 
 **Step 2: Generate some load**
 

--- a/docs/root/intro/arch_overview/outlier.rst
+++ b/docs/root/intro/arch_overview/outlier.rst
@@ -20,7 +20,7 @@ ejection algorithm works as follows:
 
 #. A host is determined to be an outlier.
 #. Envoy checks to make sure the number of ejected hosts is below the allowed threshold (specified
-   via the :ref:`outlier_detection.max_ejection_percent 
+   via the :ref:`outlier_detection.max_ejection_percent
    <config_cluster_manager_cluster_outlier_detection>` setting).
    If the number of ejected hosts is above the threshold the host is not ejected.
 #. The host is ejected for some number of milliseconds. Ejection means that the host is marked

--- a/docs/root/intro/arch_overview/redis.rst
+++ b/docs/root/intro/arch_overview/redis.rst
@@ -167,7 +167,7 @@ For details on each command's usage see the official
   SETRANGE, String
   STRLEN, String
 
-Failure modes 
+Failure modes
 -------------
 
 If Redis throws an error, we pass that error along as the response to the command. Envoy treats a

--- a/docs/root/intro/arch_overview/service_discovery.rst
+++ b/docs/root/intro/arch_overview/service_discovery.rst
@@ -57,12 +57,12 @@ Original destination
 ^^^^^^^^^^^^^^^^^^^^
 
 Original destination cluster can be used when incoming connections are redirected to Envoy either
-via an iptables REDIRECT rule or with Proxy Protocol.  In these cases requests routed to an original
+via an iptables REDIRECT rule or with Proxy Protocol. In these cases requests routed to an original
 destination cluster are forwarded to upstream hosts as addressed by the redirection metadata,
-without any explicit host configuration or upstream host discovery.  Connections to upstream hosts
+without any explicit host configuration or upstream host discovery. Connections to upstream hosts
 are pooled and unused hosts are flushed out when they have been idle longer than
 :ref:`*cleanup_interval_ms* <config_cluster_manager_cluster_cleanup_interval_ms>`, which defaults to
-5000ms.  If the original destination address is is not available, no upstream connection is opened.
+5000ms. If the original destination address is is not available, no upstream connection is opened.
 Original destination service discovery must be used with the original destination :ref:`load
 balancer <arch_overview_load_balancing_types_original_destination>`.
 

--- a/docs/root/intro/arch_overview/ssl.rst
+++ b/docs/root/intro/arch_overview/ssl.rst
@@ -19,7 +19,7 @@ requirements (TLS1.2, SNI, etc.). Envoy supports the following TLS features:
 * **SNI**: SNI is currently supported for client connections. Listener support is likely to be added
   in the future.
 * **Session resumption**: Server connections support resuming previous sessions via TLS session
-  tickets (see `RFC 5077 <https://www.ietf.org/rfc/rfc5077.txt>`_).  Resumption can be performed
+  tickets (see `RFC 5077 <https://www.ietf.org/rfc/rfc5077.txt>`_). Resumption can be performed
   across hot restarts and between parallel Envoy instances (typically useful in a front proxy
   configuration).
 

--- a/docs/root/intro/arch_overview/threading_model.rst
+++ b/docs/root/intro/arch_overview/threading_model.rst
@@ -9,5 +9,5 @@ filtering, and forwarding. Once a connection is accepted by a listener, the conn
 rest of its lifetime bound to a single worker thread. This allows the majority of Envoy to be
 largely single threaded (embarrassingly parallel) with a small amount of more complex code handling
 coordination between the worker threads. Generally Envoy is written to be 100% non-blocking and for
-most workloads we recommend configuring the number of worker threads to be equal to the number of 
+most workloads we recommend configuring the number of worker threads to be equal to the number of
 hardware threads on the machine.

--- a/docs/root/intro/comparison.rst
+++ b/docs/root/intro/comparison.rst
@@ -102,7 +102,7 @@ versus a library that must be built into something by each project individually.
 
 gRPC is a new multi-platform message passing system out of Google. It uses an IDL to describe an RPC
 library and then implements application specific runtimes for a variety of different languages. The
-underlying transport is HTTP/2.  Although gRPC likely has the goal of implementing many Envoy like
+underlying transport is HTTP/2. Although gRPC likely has the goal of implementing many Envoy like
 features in the future (load balancing, etc.), as of this writing the various runtimes are somewhat
 immature and are primarily focused on serialization/de-serialization. We consider gRPC to be a
 companion to Envoy versus a competitor. How Envoy integrates with gRPC is described :ref:`here

--- a/docs/root/operations/cli.rst
+++ b/docs/root/operations/cli.rst
@@ -68,8 +68,8 @@ following are the command line options that Envoy supports.
 
 .. option:: --log-path <path string>
 
-   *(optional)* The output file path where logs should be written.  This file will be re-opened
-   when SIGUSR1 is handled.  If this is not set, log to stderr.
+   *(optional)* The output file path where logs should be written. This file will be re-opened
+   when SIGUSR1 is handled. If this is not set, log to stderr.
 
 .. option:: --restart-epoch <integer>
 

--- a/tools/check_format.py
+++ b/tools/check_format.py
@@ -33,7 +33,7 @@ def isBuildFile(file_path):
 def checkFileContents(file_path):
   with open(file_path) as f:
     text = f.read()
-    if re.search('\.  ', text, re.MULTILINE):
+    if re.search('[^.]\.  ', text, re.MULTILINE):
       printError("%s has over-enthusiastic spaces" % file_path)
       return False
   return True
@@ -43,7 +43,7 @@ def fixFileContents(file_path):
   for line in fileinput.input(file_path, inplace=True):
     # Strip double space after '.'  This may prove overenthusiastic and need to
     # be restricted to comments and metadata files but works for now.
-    print "%s" % (line.replace('.  ', '. ').rstrip())
+    print "%s" % (line.replace('[^.].  ', '. ').rstrip())
 
 
 def checkFilePath(file_path):

--- a/tools/check_format.py
+++ b/tools/check_format.py
@@ -8,7 +8,8 @@ import os.path
 import sys
 
 EXCLUDED_PREFIXES = ("./generated/", "./bazel-", "./bazel/external")
-SUFFIXES = (".cc", ".h", "BUILD", ".proto")
+SUFFIXES = (".cc", ".h", "BUILD", ".proto", ".md", ".rst")
+DOCS_SUFFIX = (".md", ".rst")
 
 CLANG_FORMAT_PATH = os.getenv("CLANG_FORMAT", "clang-format-5.0")
 BUILDIFIER_PATH = os.getenv("BUILDIFIER", "/usr/lib/go/bin/buildifier")
@@ -52,6 +53,9 @@ def checkFilePath(file_path):
       printError("buildifier check failed for file: %s" % file_path)
     return
   checkFileContents(file_path)
+
+  if file_path.endswith(DOCS_SUFFIX):
+    return
   command = ("%s %s | diff -q %s - > /dev/null" % (CLANG_FORMAT_PATH, file_path,
                                                    file_path))
   if os.system(command) != 0:
@@ -64,6 +68,8 @@ def fixFilePath(file_path):
       printError("buildifier rewrite failed for file: %s" % file_path)
     return
   fixFileContents(file_path)
+  if file_path.endswith(DOCS_SUFFIX):
+    return
   command = "%s -i %s" % (CLANG_FORMAT_PATH, file_path)
   if os.system(command) != 0:
     printError("clang-format rewrite error: %s" % (file_path))


### PR DESCRIPTION
Removing extra whitespace from rst / md.
Hopefully the last format tweaks until I sort out how to merge the two sets of scripts :-)

Noteworthy: the changes to the tables.    I think they all look "good enough" but we could explicitly exempt ellipses to prevent them from being rewritten if anyone cares.