### PR TITLE
docs: update --service-{node,cluster,zone} to the v2 world.

### DIFF
--- a/api/base.proto
+++ b/api/base.proto
@@ -18,7 +18,11 @@ message Locality {
   // Region this :ref:`zone <envoy_api_field_Locality.zone>` belongs to.
   string region = 1;
 
-  // `Availability Zone (AZ)
+  // Defines the local service zone where Envoy is running. Though optional, it
+  // should be set if discovery service routing is used and the discovery
+  // service exposes :ref:`zone data <config_cluster_manager_sds_api_host_az>`,
+  // either in this message or via :option:`--service-zone`. The meaning of zone
+  // is context dependent, e.g. `Availability Zone (AZ)
   // <https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html>`_
   // on AWS, `Zone <https://cloud.google.com/compute/docs/regions-zones/>`_ on
   // GCP, etc.
@@ -34,15 +38,33 @@ message Locality {
 // management server, which may use this identifier to distinguish per Envoy
 // configuration for serving.
 message Node {
-  // An opaque node identifier for the Envoy node.
+  // An opaque node identifier for the Envoy node. This also provides the local
+  // service node name. It should be set if any of the following features are
+  // used: :ref:`statsd <arch_overview_statistics>`, :ref:`CDS
+  // <config_cluster_manager_cds>`, and :ref:`HTTP tracing
+  // <arch_overview_tracing>`, either in this message or via
+  // :option:`--service-node`.
   string id = 1;
-  // The cluster that the Envoy node belongs to.
+
+  // Defines the local service cluster name where Envoy is running. Though
+  // optional, it should be set if any of the following features are used:
+  // :ref:`statsd <arch_overview_statistics>`, :ref:`health check cluster
+  // verification <config_cluster_manager_cluster_hc_service_name>`,
+  // :ref:`runtime override directory <config_runtime_override_subdirectory>`,
+  // :ref:`user agent addition <config_http_conn_man_add_user_agent>`,
+  // :ref:`HTTP global rate limiting <config_http_filters_rate_limit>`,
+  // :ref:`CDS <config_cluster_manager_cds>`, and :ref:`HTTP tracing
+  // <arch_overview_tracing>`, either in this message or via
+  // :option:`--service-cluster`.
   string cluster = 2;
+
   // Opaque metadata extending the node identifier. Envoy will pass this
   // directly to the management server.
   google.protobuf.Struct metadata = 3;
+
   // Locality specifying where the Envoy instance is running.
   Locality locality = 4;
+
   // This is motivated by informing a management server during canary which
   // version of Envoy is being tested in a heterogeneous fleet. This will be set
   // by Envoy in management server RPCs.

--- a/docs/root/operations/cli.rst
+++ b/docs/root/operations/cli.rst
@@ -88,27 +88,50 @@ following are the command line options that Envoy supports.
 
 .. option:: --service-cluster <string>
 
-  *(optional)* Defines the local service cluster name where Envoy is running. Though optional,
-  it should be set if any of the following features are used: :ref:`statsd
-  <arch_overview_statistics>`, :ref:`health check cluster verification
-  <config_cluster_manager_cluster_hc_service_name>`, :ref:`runtime override directory
-  <config_runtime_override_subdirectory>`, :ref:`user agent addition
-  <config_http_conn_man_add_user_agent>`, :ref:`HTTP global rate limiting
-  <config_http_filters_rate_limit>`, :ref:`CDS <config_cluster_manager_cds>`, and
-  :ref:`HTTP tracing <arch_overview_tracing>`.
+  *(optional)* Defines the local service cluster name where Envoy is running. The
+  local service cluster name is first sourced from the :ref:`Bootstrap node
+  <envoy_api_field_Bootstrap.node>` message's :ref:`cluster
+  <envoy_api_field_Node.cluster>` field. This CLI option provides an alternative
+  method for specifying this value and will override any value set in bootstrap
+  configuration. It should be set if any of the following features are used:
+  :ref:`statsd <arch_overview_statistics>`, :ref:`health check cluster
+  verification <config_cluster_manager_cluster_hc_service_name>`,
+  :ref:`runtime override directory <config_runtime_override_subdirectory>`,
+  :ref:`user agent addition <config_http_conn_man_add_user_agent>`,
+  :ref:`HTTP global rate limiting <config_http_filters_rate_limit>`,
+  :ref:`CDS <config_cluster_manager_cds>`, and :ref:`HTTP tracing
+  <arch_overview_tracing>`, either via this CLI option or in the bootstrap
+  configuration.
 
 .. option:: --service-node <string>
 
-  *(optional)* Defines the local service node name where Envoy is running. Though optional,
-  it should be set if any of the following features are used: :ref:`statsd
-  <arch_overview_statistics>`, :ref:`CDS <config_cluster_manager_cds>`, and
-  :ref:`HTTP tracing <arch_overview_tracing>`.
+  *(optional)* Defines the local service node name where Envoy is running. The
+  local service node name is first sourced from the :ref:`Bootstrap node
+  <envoy_api_field_Bootstrap.node>` message's :ref:`id
+  <envoy_api_field_Node.id>` field. This CLI option provides an alternative
+  method for specifying this value and will override any value set in bootstrap
+  configuration. It should be set if any of the following features are used:
+  :ref:`statsd <arch_overview_statistics>`, :ref:`CDS
+  <config_cluster_manager_cds>`, and :ref:`HTTP tracing
+  <arch_overview_tracing>`, either via this CLI option or in the bootstrap
+  configuration.
 
 .. option:: --service-zone <string>
 
-  *(optional)* Defines the local service zone where Envoy is running. Though optional, it should
-  be set if discovery service routing is used and the discovery service exposes :ref:`zone data
-  <config_cluster_manager_sds_api_host_az>`.
+  *(optional)* Defines the local service zone where Envoy is running. The local
+  service zone is first sourced from the :ref:`Bootstrap node
+  <envoy_api_field_Bootstrap.node>` message's :ref:`locality.zone
+  <envoy_api_field_Locality.zone>` field. This CLI option provides an
+  alternative method for specifying this value and will override any value set
+  in bootstrap configuration. It should be set if discovery service routing is
+  used and the discovery service exposes :ref:`zone data
+  <config_cluster_manager_sds_api_host_az>`, either via this CLI option or in
+  the bootstrap configuration. The meaning of zone is context dependent, e.g.
+  `Availability Zone (AZ)
+  <https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html>`_
+  on AWS, `Zone <https://cloud.google.com/compute/docs/regions-zones/>`_ on GCP,
+  etc.
+
 
 .. option:: --file-flush-interval-msec <integer>
 


### PR DESCRIPTION
This patch clarifies the relationship between the CLI flags for local
service configuration and the bootstrap node identifier, where these
concepts are also expressed.

Signed-off-by: Harvey Tuch <htuch@google.com>