### PR TITLE
api: add some missing enum.defined_only constraints.

### DIFF
--- a/api/address.proto
+++ b/api/address.proto
@@ -20,7 +20,7 @@ message SocketAddress {
     // [#not-implemented-hide:]
     UDP = 1;
   }
-  Protocol protocol = 1;
+  Protocol protocol = 1 [(validate.rules).enum.defined_only = true];
   // The address for this socket. :ref:`Listeners <config_listeners>` will bind
   // to the address or outbound connections will be made. An empty address
   // implies a bind to 0.0.0.0 or ::. It's still possible to distinguish on an

--- a/api/base.proto
+++ b/api/base.proto
@@ -149,7 +149,7 @@ message ApiConfigSource {
     // gRPC v2 API.
     GRPC = 2;
   }
-  ApiType api_type = 1;
+  ApiType api_type = 1 [(validate.rules).enum.defined_only = true];
   // Multiple cluster names may be provided. If > 1 cluster is defined, clusters
   // will be cycled through if any kind of failure occurs.
   repeated string cluster_name = 2 [(validate.rules).repeated .min_items = 1];

--- a/api/cds.proto
+++ b/api/cds.proto
@@ -422,6 +422,7 @@ message CircuitBreakers {
   message Thresholds {
     // The :ref:`RoutingPriority<envoy_api_enum_RoutingPriority>`
     // the specified CircuitBreaker settings apply to.
+    // [#comment:TODO(htuch): add (validate.rules).enum.defined_only = true once https://github.com/lyft/protoc-gen-validate/issues/42 is resolved.]
     RoutingPriority priority = 1;
 
     // The maximum number of connections that Envoy will make to the upstream

--- a/api/cds.proto
+++ b/api/cds.proto
@@ -422,7 +422,8 @@ message CircuitBreakers {
   message Thresholds {
     // The :ref:`RoutingPriority<envoy_api_enum_RoutingPriority>`
     // the specified CircuitBreaker settings apply to.
-    // [#comment:TODO(htuch): add (validate.rules).enum.defined_only = true once https://github.com/lyft/protoc-gen-validate/issues/42 is resolved.]
+    // [#comment:TODO(htuch): add (validate.rules).enum.defined_only = true once
+    // https://github.com/lyft/protoc-gen-validate/issues/42 is resolved.]
     RoutingPriority priority = 1;
 
     // The maximum number of connections that Envoy will make to the upstream

--- a/api/filter/accesslog/accesslog.proto
+++ b/api/filter/accesslog/accesslog.proto
@@ -150,6 +150,7 @@ message TCPAccessLogEntry {
 // [#not-implemented-hide:] Not configuration. TBD how to doc proto APIs.
 message HTTPRequestProperties {
   // The request method (RFC 7231/2616).
+  // [#comment:TODO(htuch): add (validate.rules).enum.defined_only = true once https://github.com/lyft/protoc-gen-validate/issues/42 is resolved.]
   RequestMethod request_method = 1;
 
   // The scheme portion of the incoming request URI.

--- a/api/filter/accesslog/accesslog.proto
+++ b/api/filter/accesslog/accesslog.proto
@@ -150,7 +150,8 @@ message TCPAccessLogEntry {
 // [#not-implemented-hide:] Not configuration. TBD how to doc proto APIs.
 message HTTPRequestProperties {
   // The request method (RFC 7231/2616).
-  // [#comment:TODO(htuch): add (validate.rules).enum.defined_only = true once https://github.com/lyft/protoc-gen-validate/issues/42 is resolved.]
+  // [#comment:TODO(htuch): add (validate.rules).enum.defined_only = true once
+  // https://github.com/lyft/protoc-gen-validate/issues/42 is resolved.]
   RequestMethod request_method = 1;
 
   // The scheme portion of the incoming request URI.

--- a/api/rds.proto
+++ b/api/rds.proto
@@ -431,7 +431,8 @@ message RouteAction {
   RequestMirrorPolicy request_mirror_policy = 10;
 
   // Optionally specifies the :ref:`routing priority <arch_overview_http_routing_priority>`.
-  // [#comment:TODO(htuch): add (validate.rules).enum.defined_only = true once https://github.com/lyft/protoc-gen-validate/issues/42 is resolved.]
+  // [#comment:TODO(htuch): add (validate.rules).enum.defined_only = true once
+  // https://github.com/lyft/protoc-gen-validate/issues/42 is resolved.]
   RoutingPriority priority = 11;
 
   // Specifies a set of headers that will be added to requests matching this
@@ -624,7 +625,8 @@ message VirtualCluster {
 
   // Optionally specifies the HTTP method to match on. For example GET, PUT,
   // etc.
-  // [#comment:TODO(htuch): add (validate.rules).enum.defined_only = true once https://github.com/lyft/protoc-gen-validate/issues/42 is resolved.]
+  // [#comment:TODO(htuch): add (validate.rules).enum.defined_only = true once
+  // https://github.com/lyft/protoc-gen-validate/issues/42 is resolved.]
   RequestMethod method = 3;
 }
 

--- a/api/rds.proto
+++ b/api/rds.proto
@@ -431,6 +431,7 @@ message RouteAction {
   RequestMirrorPolicy request_mirror_policy = 10;
 
   // Optionally specifies the :ref:`routing priority <arch_overview_http_routing_priority>`.
+  // [#comment:TODO(htuch): add (validate.rules).enum.defined_only = true once https://github.com/lyft/protoc-gen-validate/issues/42 is resolved.]
   RoutingPriority priority = 11;
 
   // Specifies a set of headers that will be added to requests matching this
@@ -623,6 +624,7 @@ message VirtualCluster {
 
   // Optionally specifies the HTTP method to match on. For example GET, PUT,
   // etc.
+  // [#comment:TODO(htuch): add (validate.rules).enum.defined_only = true once https://github.com/lyft/protoc-gen-validate/issues/42 is resolved.]
   RequestMethod method = 3;
 }
 

--- a/tools/protodoc/protodoc.py
+++ b/tools/protodoc/protodoc.py
@@ -22,7 +22,7 @@ WKT_NAMESPACE_PREFIX = '.google.protobuf.'
 UNICODE_INVISIBLE_SEPARATOR = u'\u2063'
 
 # Key-value annotation regex.
-ANNOTATION_REGEX = re.compile('\[#([\w-]+?):(.*?)\]\s?')
+ANNOTATION_REGEX = re.compile('\[#([\w-]+?):(.*?)\]\s?', re.DOTALL)
 
 # Page/section titles with special prefixes in the proto comments
 DOC_TITLE_ANNOTATION = 'protodoc-title'
@@ -99,18 +99,16 @@ def ExtractAnnotations(s, inherited_annotations=None, type_name='file'):
       for k, v in (inherited_annotations or {}).items()
       if k in INHERITED_ANNOTATIONS
   }
-  stripped_lines = []
-  for line in s.split('\n'):
-    groups = re.findall(ANNOTATION_REGEX, line)
-    stripped_line = re.sub(ANNOTATION_REGEX, '', line)
-    if stripped_line.strip() or not groups:
-      stripped_lines.append(stripped_line)
-    for group in groups:
-      annotation = group[0]
-      if annotation not in VALID_ANNOTATIONS:
-        raise ProtodocError('Unknown annotation: %s' % annotation)
-      annotations[group[0]] = group[1].lstrip()
-  return FormatCommentWithAnnotations('\n'.join(stripped_lines), annotations,
+  # Extract annotations.
+  groups = re.findall(ANNOTATION_REGEX, s)
+  # Remove annotations.
+  without_annotations = re.sub(ANNOTATION_REGEX, '', s)
+  for group in groups:
+    annotation = group[0]
+    if annotation not in VALID_ANNOTATIONS:
+      raise ProtodocError('Unknown annotation: %s' % annotation)
+    annotations[group[0]] = group[1].lstrip()
+  return FormatCommentWithAnnotations(without_annotations, annotations,
                                       type_name), annotations
 
 


### PR DESCRIPTION
These were lost in my backlog. Required a PGV fix for cross-package enum
validation to deal with the TODOs, see
https://github.com/lyft/protoc-gen-validate/issues/42.

Signed-off-by: Harvey Tuch <htuch@google.com>