### PR TITLE
address: make bind any explicit.

### DIFF
--- a/api/address.proto
+++ b/api/address.proto
@@ -22,14 +22,15 @@ message SocketAddress {
   }
   Protocol protocol = 1;
   // The address for this socket. :ref:`Listeners <config_listeners>` will bind
-  // to the address or outbound connections will be made. An empty address
-  // implies a bind to 0.0.0.0 or ::. It's still possible to distinguish on an
-  // address via the prefix/suffix matching in FilterChainMatch after connection.
-  // For :ref:`clusters <config_cluster_manager_cluster>`, an address may be
-  // either an IP or hostname to be resolved via DNS. If it is a hostname,
-  // :ref:`resolver_name <envoy_api_field_SocketAddress.resolver_name>` should
-  // be set unless default (i.e. DNS) resolution is expected.
-  string address = 2;
+  // to the address or outbound connections will be made. An empty address is
+  // not allowed, specify 0.0.0.0 or :: to bind any. It's still possible to
+  // distinguish on an address via the prefix/suffix matching in
+  // FilterChainMatch after connection. For :ref:`clusters
+  // <config_cluster_manager_cluster>`, an address may be either an IP or
+  // hostname to be resolved via DNS. If it is a hostname, :ref:`resolver_name
+  // <envoy_api_field_SocketAddress.resolver_name>` should be set unless default
+  // (i.e. DNS) resolution is expected.
+  string address = 2 [(validate.rules).string.min_bytes = 1];
   oneof port_specifier {
     option (validate.required) = true;
     uint32 port_value = 3;

--- a/api/address.proto
+++ b/api/address.proto
@@ -23,7 +23,7 @@ message SocketAddress {
   Protocol protocol = 1;
   // The address for this socket. :ref:`Listeners <config_listeners>` will bind
   // to the address or outbound connections will be made. An empty address is
-  // not allowed, specify 0.0.0.0 or :: to bind any. It's still possible to
+  // not allowed, specify ``0.0.0.0`` or ``::`` to bind any. It's still possible to
   // distinguish on an address via the prefix/suffix matching in
   // FilterChainMatch after connection. For :ref:`clusters
   // <config_cluster_manager_cluster>`, an address may be either an IP or
@@ -65,7 +65,7 @@ message Address {
 // CidrRange specifies an IP Address and a prefix length to construct
 // the subnet mask for a `CIDR <https://tools.ietf.org/html/rfc4632>`_ range.
 message CidrRange {
-  // IPv4 or IPv6 address, e.g. 192.0.0.0 or 2001:db8::.
+  // IPv4 or IPv6 address, e.g. ``192.0.0.0`` or ``2001:db8::``.
   string address_prefix = 1 [(validate.rules).string.min_bytes = 1];
   // Length of prefix, e.g. 0, 32.
   google.protobuf.UInt32Value prefix_len = 2 [(validate.rules).uint32.lte = 128];


### PR DESCRIPTION
To resolve https://github.com/envoyproxy/envoy/issues/2155, it seems
better to fix via docs than implementation. This is because we have a
choice of binding 0.0.0.0 or ::, and the current Envoy idiom is to make
the user be explicit rather than probe.

It's possible to use :: for both IPv4/v6, for example, in
certain environments where /proc/sys/net/ipv6/bindv6only is set to 0. We
could add support to Envoy and the API for IPV6_V6ONLY to override this,
but this is orthogonal to the above issue.

Signed-off-by: Harvey Tuch <htuch@google.com>