### PR TITLE
address: support IPv4/IPv6 dual bind.

### DIFF
--- a/api/address.proto
+++ b/api/address.proto
@@ -46,9 +46,9 @@ message SocketAddress {
   string resolver_name = 5;
 
   // When binding to an IPv6 address above, this enables `IPv4 compatibity
-  // <https://tools.ietf.org/html/rfc3493#page-11>`_. Binding to :: will allow
-  // both IPv4 and IPv6 connections, with peer IPv4 addresses mapped into IPv6
-  // space as ::FFFF:<IPv4-address>.
+  // <https://tools.ietf.org/html/rfc3493#page-11>`_. Binding to ``::`` will
+  // allow both IPv4 and IPv6 connections, with peer IPv4 addresses mapped into
+  // IPv6 space as ``::FFFF:<IPv4-address>``.
   bool ipv4_compat = 6;
 }
 

--- a/api/address.proto
+++ b/api/address.proto
@@ -43,6 +43,12 @@ message SocketAddress {
   // should be set for resolution other than DNS. If the address is a concrete
   // IP address, no resolution will occur.
   string resolver_name = 5;
+
+  // When binding to an IPv6 address above, this enables `IPv4 compatibity
+  // <https://tools.ietf.org/html/rfc3493#page-11>`_. Binding to :: will allow
+  // both IPv4 and IPv6 connections, with peer IPv4 addresses mapped into IPv6
+  // space as ::FFFF:<IPv4-address>.
+  bool ipv4_compat = 6;
 }
 
 message BindConfig {


### PR DESCRIPTION
This is the same as haproxy's v4v6 bind option:
https://serverfault.com/questions/747895/bind-to-all-interfaces-for-ipv4-and-ipv6-in-haproxy.

Signed-off-by: Harvey Tuch <htuch@google.com>