### PR TITLE
Clarify docs on trusted_ca

### DIFF
--- a/api/cds.proto
+++ b/api/cds.proto
@@ -154,9 +154,11 @@ message Cluster {
   // The TLS configuration for connections to the upstream cluster. If no TLS
   // configuration is specified, TLS will not be used for new connections.
   //
-  // Server certificate verification is not enabled by default. Configure
-  // :ref:`trusted_ca<envoy_api_field_CertificateValidationContext.trusted_ca>`
-  // to enable verification.
+  // .. attention::
+  //
+  //   Server certificate verification is not enabled by default. Configure
+  //   :ref:`trusted_ca<envoy_api_field_CertificateValidationContext.trusted_ca>` to enable
+  //   verification.
   UpstreamTlsContext tls_context = 11;
 
   oneof protocol_options {

--- a/api/cds.proto
+++ b/api/cds.proto
@@ -153,6 +153,10 @@ message Cluster {
 
   // The TLS configuration for connections to the upstream cluster. If no TLS
   // configuration is specified, TLS will not be used for new connections.
+  //
+  // Server certificate verification is not enabled by default. Configure
+  // :ref:`trusted_ca<envoy_api_field_CertificateValidationContext.trusted_ca>`
+  // to enable verification.
   UpstreamTlsContext tls_context = 11;
 
   oneof protocol_options {

--- a/api/sds.proto
+++ b/api/sds.proto
@@ -148,6 +148,9 @@ message CertificateValidationContext {
   // <envoy_api_field_CertificateValidationContext.verify_certificate_hash>`, or
   // :ref:`verify_subject_alt_name
   // <envoy_api_field_CertificateValidationContext.verify_subject_alt_name>`) is also specified.
+  //
+  // See :ref:`the TLS overview <arch_overview_ssl_enabling_verification>` for a list of common
+  // system CA locations.
   DataSource trusted_ca = 1;
 
   // If specified, Envoy will verify (pin) the hex-encoded SHA-256 hash of

--- a/api/sds.proto
+++ b/api/sds.proto
@@ -139,9 +139,10 @@ message TlsSessionTicketKeys {
 
 message CertificateValidationContext {
   // TLS certificate data containing certificate authority certificates to use in verifying
-  // a presented client side certificate. If not specified and a client certificate is presented it
-  // will not be verified. By default, a client certificate is optional, unless one of the
-  // additional options (:ref:`require_client_certificate
+  // a presented peer certificate (e.g. server certificate for clusters or client certificate
+  // for listeners). If not specified and a peer certificate is presented it will not be
+  // verified. By default, a client certificate is optional, unless one of the additional
+  // options (:ref:`require_client_certificate
   // <envoy_api_field_DownstreamTlsContext.require_client_certificate>`,
   // :ref:`verify_certificate_hash
   // <envoy_api_field_CertificateValidationContext.verify_certificate_hash>`, or


### PR DESCRIPTION
CertificateValidationContext.trusted_ca is not only for client
certificates, but also for server certs. Change the wording to "peer
certificates".

Also mention that verification is not enabled by default in docs for
UpstreamTlsContext.