### PR TITLE
Add Trace Service Support.

### DIFF
--- a/api/BUILD
+++ b/api/BUILD
@@ -324,6 +324,18 @@ api_go_proto_library(
     ],
 )
 
+api_proto_library(
+    name = "trace_service",
+    srcs = ["trace_service.proto"],
+    has_services = 1,
+    require_py = 0,
+    deps = [
+        ":base",
+        ":grpc_service",
+        "@io_opencensus_trace//:trace_model",
+    ],
+)
+
 # TODO(htuch): Grow this to cover everything we want to generate docs for, so we can just invoke
 # bazel build //api --aspects tools/protodoc/protodoc.bzl%proto_doc_aspect  --output_groups=rst
 proto_library(

--- a/api/trace_service.proto
+++ b/api/trace_service.proto
@@ -1,0 +1,47 @@
+syntax = "proto3";
+
+// [#proto-status: draft]
+
+package envoy.api.v2;
+
+import "api/base.proto";
+import "api/grpc_service.proto";
+import "trace.proto";
+
+import "google/api/annotations.proto";
+
+import "validate/validate.proto";
+
+// Service for streaming traces to server that consumes the trace data. It
+// uses OpenCensus data model as a standard to represent trace information.
+service TraceService {
+  // Envoy will connect and send StreamTracesMessage messages forever. It does
+  // not expect any response to be sent as nothing would be done in the case
+  // of failure.
+  rpc StreamTraces(stream StreamTracesMessage) returns (StreamTracesResponse) {
+  }
+}
+
+message StreamTracesResponse {
+}
+
+message StreamTracesMessage {
+  message Identifier {
+    // The node sending the access log messages over the stream.
+    Node node = 1 [(validate.rules).message.required = true];
+  }
+
+  // Identifier data effectively is a structured metadata.
+  // As a performance optimization this will only be sent in the first message
+  // on the stream.
+  Identifier identifier = 1;
+
+  // A list of Span entries
+  repeated opencensus.proto.trace.Span spans = 2;
+}
+
+// Configuration structure.
+message TraceServiceConfig {
+  // The upstream gRPC cluster that hosts the metrics service.
+  GrpcService grpc_service = 1 [(validate.rules).message.required = true];
+}

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -1,6 +1,7 @@
 GOOGLEAPIS_SHA = "5c6df0cd18c6a429eab739fb711c27f6e1393366" # May 14, 2017
 GOGOPROTO_SHA = "342cbe0a04158f6dcb03ca0079991a51a4248c02" # Oct 7, 2017
 PROMETHEUS_SHA = "6f3806018612930941127f2a7c6c453ba2c527d2" # Nov 02, 2017
+OPENCENSUS_SHA = "993c711ba22a5f08c1d4de58a3c07466995ed962" # Dec 13, 2017
 
 PGV_GIT_SHA = "bd6d057e957fe184dfe76805951803af153be497"
 
@@ -200,3 +201,21 @@ api_proto_library(
 )
         """,
     )
+
+    native.new_http_archive(
+        name = "io_opencensus_trace",
+        strip_prefix = "opencensus-proto-" + OPENCENSUS_SHA + "/opencensus/proto/trace",
+        url = "https://github.com/census-instrumentation/opencensus-proto/archive/" + OPENCENSUS_SHA + ".tar.gz",
+        build_file_content = """
+load("@envoy_api//bazel:api_build_system.bzl", "api_proto_library")
+
+api_proto_library(
+    name = "trace_model",
+    srcs = [
+        "trace.proto",
+    ],
+)
+        """,
+    )
+
+


### PR DESCRIPTION
This is a trace service proposal based on the opencensus (opencensus.io) data model. OpenCensus is an vendor independent tracing (support for zipkin, stackdriver, and soon others) and stats library(prometheus, stackdirver, signalfx, and soon others), integrated in products like gRPC (grpc.io).

One of the usages will be in the Istio (istio.io) environment to push traces to the Mixer.

/cc @douglas-reid @louiscryan