### PR TITLE
Add tcp and http filter for external authorization checker grpc server.

### DIFF
--- a/api/BUILD
+++ b/api/BUILD
@@ -67,6 +67,11 @@ api_proto_library(
 )
 
 api_proto_library(
+    name = "grpc_cluster",
+    srcs = ["grpc_cluster.proto"],
+)
+
+api_proto_library(
     name = "hds",
     srcs = ["hds.proto"],
     has_services = 1,
@@ -166,6 +171,7 @@ proto_library(
         ":rls",
         "//api/filter/accesslog",
         "//api/filter/http:buffer",
+        "//api/filter/http:ext_authz",
         "//api/filter/http:fault",
         "//api/filter/http:health_check",
         "//api/filter/http:lua",
@@ -174,6 +180,7 @@ proto_library(
         "//api/filter/http:squash",
         "//api/filter/http:transcoder",
         "//api/filter/network:client_ssl_auth",
+        "//api/filter/network:ext_authz",
         "//api/filter/network:http_connection_manager",
         "//api/filter/network:mongo_proxy",
         "//api/filter/network:rate_limit",

--- a/api/auth/external_auth.proto
+++ b/api/auth/external_auth.proto
@@ -42,8 +42,8 @@ message AttributeContext {
     Address address = 1;
 
     // The canonical service name of the peer.
-    // It should be set to :ref:`x-envoy-downstream-service-cluster
-    // <https://www.envoyproxy.io/docs/envoy/latest/configuration/http_conn_man/headers#x-envoy-downstream-service-cluster>`
+    // It should be set to :ref:`the HTTP x-envoy-downstream-service-cluster
+    // <config_http_conn_man_headers_downstream-service-cluster>`
     // If a more trusted source of the service name is available through mTLS/secure naming, it
     // should be used.
     string service = 2;

--- a/api/filter/http/BUILD
+++ b/api/filter/http/BUILD
@@ -57,3 +57,9 @@ api_proto_library(
     name = "squash",
     srcs = ["squash.proto"],
 )
+
+api_proto_library(
+    name = "ext_authz",
+    srcs = ["ext_authz.proto"],
+    deps = ["//api:grpc_cluster"],
+)

--- a/api/filter/http/ext_authz.proto
+++ b/api/filter/http/ext_authz.proto
@@ -1,0 +1,25 @@
+syntax = "proto3";
+
+package envoy.api.v2.filter.http;
+
+import "api/grpc_cluster.proto";
+
+import "validate/validate.proto";
+
+// [#not-implemented-hide:]
+// External Authorization filter calls out to an external service over the
+// gRPC Authorization API defined by :ref:`external_auth <envoy_api_msg_auth.CheckRequest>`.
+// A failed check will cause this filter to return 403 Forbidden.
+message ExtAuthz {
+
+  // The external authorization gRPC service configuration.
+  GrpcCluster grpc_cluster = 1;
+
+  // The filter's behaviour in case the external authorization service does
+  // not respond back. If set to true then in case of failure to get a
+  // response back from the authorization service allow the traffic.
+  // Defaults to false.
+  // If set to true and the response from the authorization service is NOT
+  // Denied then the traffic will be permitted.
+  bool failure_mode_allow = 2;
+}

--- a/api/filter/network/BUILD
+++ b/api/filter/network/BUILD
@@ -44,3 +44,9 @@ api_proto_library(
     srcs = ["rate_limit.proto"],
     deps = ["//api:rls"],
 )
+
+api_proto_library(
+    name = "ext_authz",
+    srcs = ["ext_authz.proto"],
+    deps = ["//api:grpc_cluster"],
+)

--- a/api/filter/network/ext_authz.proto
+++ b/api/filter/network/ext_authz.proto
@@ -1,0 +1,27 @@
+syntax = "proto3";
+
+package envoy.api.v2.filter.network;
+
+import "api/grpc_cluster.proto";
+
+import "validate/validate.proto";
+
+// [#not-implemented-hide:]
+// External Authorization filter calls out to an external service over the
+// gRPC Authorization API defined by :ref:`external_auth <envoy_api_msg_auth.CheckRequest>`.
+// A failed check will cause this filter to close the TCP connection.
+message ExtAuthz {
+  // The prefix to use when emitting statistics.
+  string stat_prefix = 1 [(validate.rules).string.min_bytes = 1];
+
+  // The external authorization gRPC service configuration.
+  GrpcCluster grpc_cluster = 2;
+
+  // The filter's behaviour in case the external authorization service does
+  // not respond back. If set to true then in case of failure to get a
+  // response back from the authorization service allow the traffic.
+  // Defaults to false.
+  // If set to true and the response from the authorization service is NOT
+  // Denied then the traffic will be permitted.
+  bool failure_mode_allow = 3;
+}

--- a/api/grpc_cluster.proto
+++ b/api/grpc_cluster.proto
@@ -1,0 +1,19 @@
+syntax = "proto3";
+
+package envoy.api.v2;
+
+import "google/protobuf/duration.proto";
+
+import "validate/validate.proto";
+
+// [#not-implemented-hide:]
+// GrpcCluster is used to expose generic gRPC cluster configuration that may
+// be used by filters to interface with a gRPC service.
+message GrpcCluster {
+  // The name of the upstream gRPC cluster.
+  string cluster_name = 1 [(validate.rules).string.min_bytes = 1];
+
+  // The timeout for the gRPC request. This is the timeout for a specific
+  // request.
+  google.protobuf.Duration timeout = 2;
+}


### PR DESCRIPTION
Add support for configuration of TCP, HTTP filters to support external authorization cluster.

The filter configuration references an external cluster which is expected to be running the grpc server that supports the service being defined by https://github.com/envoyproxy/data-plane-api/pull/296

cc: @mandarjog, @wora, @spikecurtis