### PR TITLE
Move request.http_request to ac.request in envoy.api.v2.auth package.

### DIFF
--- a/api/auth/external_auth.proto
+++ b/api/auth/external_auth.proto
@@ -63,15 +63,6 @@ message AttributeContext {
     string principal = 4;
   }
 
-  // Represents a network request, such as an HTTP request.
-  message Request {
-    oneof request {
-      HTTPRequest http_request = 1;
-    }
-    // The timestamp when the proxy receives the first byte of the request.
-    google.protobuf.Timestamp time = 2;
-  }
-
   // This message defines attributes for an HTTP request.
   // HTTP, H2, grpc are all considered http requests.
   message HTTPRequest {
@@ -112,6 +103,9 @@ message AttributeContext {
     // The network protocol used with the request, such as
     // "http/1.1", "spdy/3", "h2", "h2c"
     string protocol = 10;
+
+    // The timestamp when the proxy receives the first byte of the request.
+    google.protobuf.Timestamp time = 11;
   }
 
   // The source of a network activity, such as starting a TCP connection.
@@ -125,7 +119,11 @@ message AttributeContext {
   Peer destination = 2;
 
   // Represents a network request, such as an HTTP request.
-  Request request = 4;
+  oneof req {
+    // HTTPRequest represents the most common form of network request.
+    HTTPRequest request = 3;
+    // Other request types will be defined here as needed.
+  }
 
   // This is analogous to http_request.headers, however these contents will not be sent to the
   // upstream server. Context_extensions provide an extension mechanism for sending additional

--- a/api/auth/external_auth.proto
+++ b/api/auth/external_auth.proto
@@ -63,6 +63,17 @@ message AttributeContext {
     string principal = 4;
   }
 
+  // Represents a network request, such as an HTTP request.
+  message Request {
+    // The timestamp when the proxy receives the first byte of the request.
+    google.protobuf.Timestamp time = 1;
+
+    // HTTP and related requests.
+    HTTPRequest http = 2;
+
+    // More requests types are added here as necessary.
+  }
+
   // This message defines attributes for an HTTP request.
   // HTTP, H2, grpc are all considered http requests.
   message HTTPRequest {
@@ -103,9 +114,6 @@ message AttributeContext {
     // The network protocol used with the request, such as
     // "http/1.1", "spdy/3", "h2", "h2c"
     string protocol = 10;
-
-    // The timestamp when the proxy receives the first byte of the request.
-    google.protobuf.Timestamp time = 11;
   }
 
   // The source of a network activity, such as starting a TCP connection.
@@ -119,11 +127,7 @@ message AttributeContext {
   Peer destination = 2;
 
   // Represents a network request, such as an HTTP request.
-  oneof req {
-    // HTTPRequest represents the most common form of network request.
-    HTTPRequest request = 3;
-    // Other request types will be defined here as needed.
-  }
+  Request request = 4;
 
   // This is analogous to http_request.headers, however these contents will not be sent to the
   // upstream server. Context_extensions provide an extension mechanism for sending additional

--- a/api/auth/external_auth.proto
+++ b/api/auth/external_auth.proto
@@ -71,7 +71,7 @@ message AttributeContext {
     // HTTP and related requests.
     HTTPRequest http = 2;
 
-    // More requests types are added here as necessary.
+    // More request types are added here as necessary.
   }
 
   // This message defines attributes for an HTTP request.


### PR DESCRIPTION
This PR eliminates `Request` as a separate message and moves the definition as an inline `oneof`.

The advantage of this approach is that on the policy authoring side the most common form of http request becomes `attributeContext.request` instead of `attributeContext.request.http_request`

Other forms of requests can be added later as `attributeContext.redis_request`, etc.

Signed-off-by: Mandar U Jog <mjog@google.com>