### PR TITLE
access log: add additional downstream tx time fields

### DIFF
--- a/api/filter/accesslog/accesslog.proto
+++ b/api/filter/accesslog/accesslog.proto
@@ -43,7 +43,8 @@ message AccessLogCommon {
   // If the connection is secure, this field will contain TLS properties.
   TLSProperties tls_properties = 4;
 
-  // The time that Envoy started servicing this request
+  // The time that Envoy started servicing this request. This is effectively the time that the first
+  // downstream byte is received.
   google.protobuf.Timestamp start_time = 5;
 
   // Interval between the first downstream byte received and the last
@@ -71,7 +72,7 @@ message AccessLogCommon {
   google.protobuf.Duration time_to_last_upstream_rx_byte = 10;
 
   // Interval between the first downstream byte received and the first downstream byte sent.
-  // There may be a considerable delta between the *time_to_last_upstream_rx_byte* and this field
+  // There may be a considerable delta between the *time_to_first_upstream_rx_byte* and this field
   // due to filters. Additionally, the same caveats apply as documented in
   // *time_to_last_downstream_tx_byte* about not accounting for kernel socket buffer time, etc.
   google.protobuf.Duration time_to_first_downstream_tx_byte = 11;

--- a/api/filter/accesslog/accesslog.proto
+++ b/api/filter/accesslog/accesslog.proto
@@ -50,26 +50,52 @@ message AccessLogCommon {
   // downstream byte received (i.e. time it takes to receive a request).
   google.protobuf.Duration time_to_last_rx_byte = 6;
 
+  // Interval between the first downstream byte received and the first upstream byte sent. There may
+  // by considerable delta between *time_to_last_rx_byte* and this value due to filters.
+  // Additionally, the same caveats apply as documented in *time_to_last_downstream_tx_byte* about
+  // not accounting for kernel socket buffer time, etc.
+  google.protobuf.Duration time_to_first_upstream_tx_byte = 7;
+
+  // Interval between the first downstream byte received and the last upstream byte sent. There may
+  // by considerable delta between *time_to_last_rx_byte* and this value due to filters.
+  // Additionally, the same caveats apply as documented in *time_to_last_downstream_tx_byte* about
+  // not accounting for kernel socket buffer time, etc.
+  google.protobuf.Duration time_to_last_upstream_tx_byte = 8;
+
   // Interval between the first downstream byte received and the first upstream
   // byte received (i.e. time it takes to start receiving a response).
-  google.protobuf.Duration time_to_first_upstream_rx_byte = 7;
+  google.protobuf.Duration time_to_first_upstream_rx_byte = 9;
 
   // Interval between the first downstream byte received and the last upstream
   // byte received (i.e. time it takes to receive a complete response).
-  google.protobuf.Duration time_to_last_upstream_rx_byte = 8;
+  google.protobuf.Duration time_to_last_upstream_rx_byte = 10;
+
+  // Interval between the first downstream byte received and the first downstream byte sent.
+  // There may be a considerable delta between the *time_to_last_upstream_rx_byte* and this field
+  // due to filters. Additionally, the same caveats apply as documented in
+  // *time_to_last_downstream_tx_byte* about not accounting for kernel socket buffer time, etc.
+  google.protobuf.Duration time_to_first_downstream_tx_byte = 11;
+
+  // Interval between the first downstream byte received and the last downstream byte sent.
+  // Depending on protocol, buffering, windowing, filters, etc. there may be a considerable delta
+  // between *time_to_last_upstream_rx_byte* and this field. Note also that this is an approximate
+  // time. In the current implementation it does not include kernel socket buffer time. In the
+  // current implementation it also does not include send window buffering inside the HTTP/2 codec.
+  // In the future it is likely that work will be done to make this duration more accurate.
+  google.protobuf.Duration time_to_last_downstream_tx_byte = 12;
 
   // The upstream remote/destination address that handles this exchange. This does not include
   // retries.
-  Address upstream_remote_address = 9;
+  Address upstream_remote_address = 13;
 
   // The upstream local/origin address that handles this exchange. This does not include retries.
-  Address upstream_local_address = 10;
+  Address upstream_local_address = 14;
 
   // The upstream cluster that *upstream_remote_address* belongs to.
-  string upstream_cluster = 11;
+  string upstream_cluster = 15;
 
   // Flags indicating occurences during request/response processing.
-  ResponseFlags response_flags = 12;
+  ResponseFlags response_flags = 16;
 
   // All metadata encountered during request processing, including endpoint
   // selection.
@@ -79,7 +105,7 @@ message AccessLogCommon {
   // route created from a higher level forwarding rule with some ID can place
   // that ID in this field and cross reference later. It can also be used to
   // determine if a canary endpoint was used or not.
-  Metadata metadata = 13;
+  Metadata metadata = 17;
 }
 
 // [#proto-status: draft]


### PR DESCRIPTION
This is needed for more accurate time accounting. In general I noticed that we were not
accounting for total duration / last byte sent. I opted for adding detailed timings in both 
directions as I think if implemented this would make it much easier to visualize filter activity,
buffering vs. streaming, etc.

Signed-off-by: Matt Klein <mklein@lyft.com>