### PR TITLE
stats: revert docs for new `--stat-tag` CLI arg (#361)

### DIFF
--- a/docs/root/operations/cli.rst
+++ b/docs/root/operations/cli.rst
@@ -132,14 +132,6 @@ following are the command line options that Envoy supports.
   on AWS, `Zone <https://cloud.google.com/compute/docs/regions-zones/>`_ on GCP,
   etc.
 
-.. option:: --stats-tag <string>
-
-  *(optional)* Defines :ref:`stats <arch_overview_statistics>` tags which will
-  be added to all metrics as tags. To add multiple tags, specify this option
-  multiple times. The tag string must have a semicolon separated format like
-  `name:value`. The tags will be only available with :ref:`stats sinks
-  <envoy_api_msg_StatsSink>` which support tagged metrics: e.g.
-  :ref:`envoy.dog_statsd <envoy_api_msg_DogStatsdSink>`.
 
 .. option:: --file-flush-interval-msec <integer>
 


### PR DESCRIPTION
This reverts commit 06ae0116c145f1ef702cab24907f40eabdd22693 and PR https://github.com/envoyproxy/data-plane-api/pull/361.

Decided not to implement `--stat-tag` CLI arg, https://github.com/envoyproxy/envoy/pull/2264. ref: https://github.com/envoyproxy/envoy/pull/2264#issuecomment-354011600.