### PR TITLE
Expose trace sampling controls in the public API

### DIFF
--- a/api/base.proto
+++ b/api/base.proto
@@ -228,10 +228,10 @@ message TransportSocket {
   google.protobuf.Struct config = 2;
 }
 
-// Percent, typically used to specify things like target sampling percentages among tracing requests
-// (as in, e.g., :ref:`HTTP Connection Manager tracing
+// A percent, rounded down to the nearest 0.01%. Typically used to specify things like target
+// sampling percentages among tracing requests (as in, e.g., :ref:`HTTP Connection Manager tracing
 // <envoy_api_field_filter.network.HttpConnectionManager.tracing>`).
-message Percent {
-  // The percent, a float between 0 and 1.
-  float value = 1 [(validate.rules).float = {gte: 0, lte: 1}];
+message HundredthsRoundedPercent {
+  // The percent, a float between 0 and 100. Rounded to the nearest 0.01%.
+  double value = 1 [(validate.rules).double = {gte: 0, lte: 100}];
 }

--- a/api/base.proto
+++ b/api/base.proto
@@ -227,3 +227,7 @@ message TransportSocket {
   // See the supported transport socket implementations for further documentation.
   google.protobuf.Struct config = 2;
 }
+
+message Percent {
+  float value = 5 [(validate.rules).float = {gte: 0, lte: 100}];
+}

--- a/api/base.proto
+++ b/api/base.proto
@@ -228,6 +228,10 @@ message TransportSocket {
   google.protobuf.Struct config = 2;
 }
 
+// Percent, typically used to specify things like target sampling percentages among tracing requests
+// (as in, e.g., :ref:`HTTP Connection Manager tracing
+// <envoy_api_field_filter.network.HttpConnectionManager.tracing>`).
 message Percent {
-  float value = 5 [(validate.rules).float = {gte: 0, lte: 100}];
+  // The percent, a float between 0 and 1.
+  float value = 1 [(validate.rules).float = {gte: 0, lte: 1}];
 }

--- a/api/filter/network/http_connection_manager.proto
+++ b/api/filter/network/http_connection_manager.proto
@@ -80,6 +80,22 @@ message HttpConnectionManager {
     // populate the tag name, and the header value is used to populate the tag value. The tag is
     // created if the specified header name is present in the request's headers.
     repeated string request_headers_for_tags = 2;
+
+    // Global target percentage of requests that will be force traced if the
+    // x-client-trace-id header is set. Must be an integer number between 0 and
+    // 100.
+    uint32 client_enabled = 3 [(validate.rules).uint32.lte = 100];
+
+    // Global target percentage of requests that will be traced after all other
+    // checks have been applied (force tracing, sampling, etc.). Must be a
+    // number between 0 and
+    // 100.
+    uint32 global_enabled = 4 [(validate.rules).uint32.lte = 100];
+
+    // Global target percentage of requests that will be randomly traced.
+    // Specified as ten-thousandths of a percent (i.e., in 0.01% increments),
+    // using integer numbers in the range 0-10000.
+    uint32 random_sampling = 5 [(validate.rules).uint32.lte = 10000];
   }
 
   // Presence of the object defines whether the connection manager

--- a/api/filter/network/http_connection_manager.proto
+++ b/api/filter/network/http_connection_manager.proto
@@ -82,23 +82,20 @@ message HttpConnectionManager {
     repeated string request_headers_for_tags = 2;
 
     // Global target percentage of requests that will be force traced if the *x-client-trace-id*
-    // header is set. Must be an number between 0 and 100; resolution is to the nearest 1% (rounded
-    // down). Defaults to 100. This variable is a direct analog for the variable of the same name in
-    // the `HTTP Connection Manager
-    // <https://www.envoyproxy.io/docs/envoy/latest/configuration/http_conn_man/runtime.html?highlight=sample>`_.
+    // header is set. Percent is resolved to the nearest 1% (rounded down). Defaults to 1 (i.e., 100%). This
+    // variable is a direct analog for the variable of the same name in the :ref:`HTTP Connection
+    // Manager <config_http_conn_man_runtime>`.
     Percent client_enabled = 3;
 
     // Global target percentage of requests that will be traced after all other checks have been
-    // applied (force tracing, sampling, etc.). Must be a number between 0 and 100; resolution is to
-    // the nearest 1% (rounded down). Defaults to 100. This variable is a direct analog for the
-    // variable of the same name in the `HTTP Connection Manager
-    // <https://www.envoyproxy.io/docs/envoy/latest/configuration/http_conn_man/runtime.html?highlight=sample>`_.
+    // applied (force tracing, sampling, etc.). Percent is resolved to the nearest 1% (rounded
+    // down). Defaults to 1 (i.e., 100%). This variable is a direct analog for the variable of the same name in
+    // the :ref:`HTTP Connection Manager <config_http_conn_man_runtime>`.
     Percent global_enabled = 4;
 
-    // Global target percentage of requests that will be randomly traced. Must be a number between 0
-    // and 100; resolution is to the nearest 0.01%, rounded down. Defaults to 100. This variable is
-    // a direct analog for the variable of the same name in the `HTTP Connection Manager
-    // <https://www.envoyproxy.io/docs/envoy/latest/configuration/http_conn_man/runtime.html?highlight=sample>`_.
+    // Global target percentage of requests that will be randomly traced. Percent is resolved to the
+    // nearest 0.01%, rounded down. Defaults to 1 (i.e., 100%). This variable is a direct analog for
+    // the variable of the same name in the :ref:`HTTP Connection Manager <config_http_conn_man_runtime>`.
     Percent random_sampling = 5;
   }
 

--- a/api/filter/network/http_connection_manager.proto
+++ b/api/filter/network/http_connection_manager.proto
@@ -82,20 +82,21 @@ message HttpConnectionManager {
     repeated string request_headers_for_tags = 2;
 
     // Global target percentage of requests that will be force traced if the *x-client-trace-id*
-    // header is set. Percent is resolved to the nearest 1% (rounded down). Defaults to 1 (i.e., 100%). This
-    // variable is a direct analog for the variable of the same name in the :ref:`HTTP Connection
-    // Manager <config_http_conn_man_runtime>`.
+    // header is set. Percent is resolved to the nearest 1% (rounded down). Defaults to 1 (i.e.,
+    // 100%). This variable is a direct analog for the variable of the same name in the :ref:`HTTP
+    // Connection Manager <config_http_conn_man_runtime>`.
     Percent client_enabled = 3;
 
     // Global target percentage of requests that will be traced after all other checks have been
     // applied (force tracing, sampling, etc.). Percent is resolved to the nearest 1% (rounded
-    // down). Defaults to 1 (i.e., 100%). This variable is a direct analog for the variable of the same name in
-    // the :ref:`HTTP Connection Manager <config_http_conn_man_runtime>`.
+    // down). Defaults to 1 (i.e., 100%). This variable is a direct analog for the variable of the
+    // same name in the :ref:`HTTP Connection Manager <config_http_conn_man_runtime>`.
     Percent global_enabled = 4;
 
     // Global target percentage of requests that will be randomly traced. Percent is resolved to the
     // nearest 0.01%, rounded down. Defaults to 1 (i.e., 100%). This variable is a direct analog for
-    // the variable of the same name in the :ref:`HTTP Connection Manager <config_http_conn_man_runtime>`.
+    // the variable of the same name in the :ref:`HTTP Connection Manager
+    // <config_http_conn_man_runtime>`.
     Percent random_sampling = 5;
   }
 

--- a/api/filter/network/http_connection_manager.proto
+++ b/api/filter/network/http_connection_manager.proto
@@ -81,21 +81,25 @@ message HttpConnectionManager {
     // created if the specified header name is present in the request's headers.
     repeated string request_headers_for_tags = 2;
 
-    // Global target percentage of requests that will be force traced if the
-    // x-client-trace-id header is set. Must be an integer number between 0 and
-    // 100.
-    uint32 client_enabled = 3 [(validate.rules).uint32.lte = 100];
+    // Global target percentage of requests that will be force traced if the *x-client-trace-id*
+    // header is set. Must be an number between 0 and 100; resolution is to the nearest 1% (rounded
+    // down). Defaults to 100. This variable is a direct analog for the variable of the same name in
+    // the `HTTP Connection Manager
+    // <https://www.envoyproxy.io/docs/envoy/latest/configuration/http_conn_man/runtime.html?highlight=sample>`_.
+    Percent client_enabled = 3;
 
-    // Global target percentage of requests that will be traced after all other
-    // checks have been applied (force tracing, sampling, etc.). Must be a
-    // number between 0 and
-    // 100.
-    uint32 global_enabled = 4 [(validate.rules).uint32.lte = 100];
+    // Global target percentage of requests that will be traced after all other checks have been
+    // applied (force tracing, sampling, etc.). Must be a number between 0 and 100; resolution is to
+    // the nearest 1% (rounded down). Defaults to 100. This variable is a direct analog for the
+    // variable of the same name in the `HTTP Connection Manager
+    // <https://www.envoyproxy.io/docs/envoy/latest/configuration/http_conn_man/runtime.html?highlight=sample>`_.
+    Percent global_enabled = 4;
 
-    // Global target percentage of requests that will be randomly traced.
-    // Specified as ten-thousandths of a percent (i.e., in 0.01% increments),
-    // using integer numbers in the range 0-10000.
-    uint32 random_sampling = 5 [(validate.rules).uint32.lte = 10000];
+    // Global target percentage of requests that will be randomly traced. Must be a number between 0
+    // and 100; resolution is to the nearest 0.01%, rounded down. Defaults to 100. This variable is
+    // a direct analog for the variable of the same name in the `HTTP Connection Manager
+    // <https://www.envoyproxy.io/docs/envoy/latest/configuration/http_conn_man/runtime.html?highlight=sample>`_.
+    Percent random_sampling = 5;
   }
 
   // Presence of the object defines whether the connection manager

--- a/api/filter/network/http_connection_manager.proto
+++ b/api/filter/network/http_connection_manager.proto
@@ -81,23 +81,22 @@ message HttpConnectionManager {
     // created if the specified header name is present in the request's headers.
     repeated string request_headers_for_tags = 2;
 
-    // Global target percentage of requests that will be force traced if the *x-client-trace-id*
-    // header is set. Percent is resolved to the nearest 1% (rounded down). Defaults to 1 (i.e.,
-    // 100%). This variable is a direct analog for the variable of the same name in the :ref:`HTTP
-    // Connection Manager <config_http_conn_man_runtime>`.
-    Percent client_enabled = 3;
-
-    // Global target percentage of requests that will be traced after all other checks have been
-    // applied (force tracing, sampling, etc.). Percent is resolved to the nearest 1% (rounded
-    // down). Defaults to 1 (i.e., 100%). This variable is a direct analog for the variable of the
-    // same name in the :ref:`HTTP Connection Manager <config_http_conn_man_runtime>`.
-    Percent global_enabled = 4;
-
-    // Global target percentage of requests that will be randomly traced. Percent is resolved to the
-    // nearest 0.01%, rounded down. Defaults to 1 (i.e., 100%). This variable is a direct analog for
-    // the variable of the same name in the :ref:`HTTP Connection Manager
+    // Target percentage of requests managed by this HTTP connectionmanager that will be force
+    // traced if the *x-client-trace-id* header is set. Defaults to 100%. This variable is a direct
+    // analog for the variable of the same name in the :ref:`HTTP Connection Manager
     // <config_http_conn_man_runtime>`.
-    Percent random_sampling = 5;
+    double client_sampling = 3 [(validate.rules).double = {gte: 0, lte: 100}];
+
+    // Target percentage of requests managed by this HTTP connection manager that will be traced
+    // after all other checks have been applied (force tracing, sampling, etc.). Defaults to 100%.
+    // This variable is a direct analog for the variable of the same name in the :ref:`HTTP
+    // Connection Manager <config_http_conn_man_runtime>`.
+    double sampling = 4 [(validate.rules).double = {gte: 0, lte: 100}];
+
+    // Target percentage of requests managed by this HTTP connection manager that will be randomly
+    // traced. Defaults to 100%. This variable is a direct analog for the variable of the same name
+    // in the :ref:`HTTP Connection Manager <config_http_conn_man_runtime>`.
+    HundredthsRoundedPercent random_sampling = 5;
   }
 
   // Presence of the object defines whether the connection manager

--- a/api/trace.proto
+++ b/api/trace.proto
@@ -29,6 +29,22 @@ message Tracing {
   }
   // Provides configuration for the HTTP tracer.
   Http http = 1;
+
+  // Global target percentage of requests that will be force traced if the
+  // x-client-trace-id header is set. Must be an integer number between 0 and
+  // 100.
+  uint32 client_enabled = 2 [(validate.rules).uint32.lte = 100];
+
+  // Global target percentage of requests that will be traced after all other
+  // checks have been applied (force tracing, sampling, etc.). Must be a number
+  // between 0 and
+  // 100.
+  uint32 global_enabled = 3 [(validate.rules).uint32.lte = 100];
+
+  // Global target percentage of requests that will be randomly traced.
+  // Specified as ten-thousandths of a percent (i.e., in 0.01% increments),
+  // using integer numbers in the range 0-10000.
+  uint32 random_sampling = 4 [(validate.rules).uint32.lte = 10000];
 }
 
 // Configuration for the LightStep tracer.

--- a/api/trace.proto
+++ b/api/trace.proto
@@ -29,22 +29,6 @@ message Tracing {
   }
   // Provides configuration for the HTTP tracer.
   Http http = 1;
-
-  // Global target percentage of requests that will be force traced if the
-  // x-client-trace-id header is set. Must be an integer number between 0 and
-  // 100.
-  uint32 client_enabled = 2 [(validate.rules).uint32.lte = 100];
-
-  // Global target percentage of requests that will be traced after all other
-  // checks have been applied (force tracing, sampling, etc.). Must be a number
-  // between 0 and
-  // 100.
-  uint32 global_enabled = 3 [(validate.rules).uint32.lte = 100];
-
-  // Global target percentage of requests that will be randomly traced.
-  // Specified as ten-thousandths of a percent (i.e., in 0.01% increments),
-  // using integer numbers in the range 0-10000.
-  uint32 random_sampling = 4 [(validate.rules).uint32.lte = 10000];
 }
 
 // Configuration for the LightStep tracer.


### PR DESCRIPTION
I'm basically completely new to Envoy, so I am probably missing some stuff you'd want to see in a PR, just let me know and I'll fix it up.

- [x] Didn't see any direct tests on the API objects that seemed like this would need to be added to, and the contributing doc didn't mention writing any, so there are none here.
- [x] Docs seem to be generated by CI, so I didn't generate any new ones.
- [x] I consulted [HTTP connection manager tracing docs][tracing] and [general tracing docs][tracing2] so I think this change is semantically right, but it is highly likely that I've misunderstood something about how they work and what they mean, so you'll want to pay close attention there.

Additional questions I think I've answered, but might be worth double-checking:

- [x] Are these mutually exclusive options, and do special precautions need to be taken as such? I think they're not, and I think it's sufficient to simply plumb these settings through to the runtime inside Envoy core.
- [x] Who is responsible for default values? I believe it should be Envoy core, since the runtime values already have defaults, and it doesn't look like we're bundling in any fancy default logic here anyway.

<hr>

Envoy core has an open issue[1] to expose the target trace sample
percentages as part of the API. This is exposed as part of the HTTP
connection manager runtime, but is not yet exposed as part of the API.
(See the issue for more details on those controls.)

This commit will introduce the 3 main runtime controls as part of the
core API.

  1. Tracing#client_enabled, which specifies the target percentage of
     requests to be force-traced. (Meant to map to HTTP connection
     manager's runtime tracing.client_enabled setting.)
  2. Tracing#global_enabled, which specifies the target percentage of
     requests to be traced after all rules and checks have been applied.
     (Meant to map to HTTP connection manager's runtime
     tracing.global_enabled setting.)
  3. Tracing#random_sampling, which specifies the number of requests to
     be randomly traced. (Meant to map to HTTP connection manager's
     runtime tracing.random_sampling setting.)

[1]: https://github.com/envoyproxy/envoy/issues/1813

Signed-off-by: Alex Clemmer <clemmer.alexander@gmail.com>

[tracing]: https://www.envoyproxy.io/docs/envoy/latest/configuration/http_conn_man/runtime.html?highlight=sample
[tracing2]: https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/tracing.html#arch-overview-tracing