### PR TITLE
Unhide the query parameter match routing from the docs

### DIFF
--- a/api/rds.proto
+++ b/api/rds.proto
@@ -281,7 +281,6 @@ message RouteMatch {
   // is not in the config).
   repeated HeaderMatcher headers = 6;
 
-  // [#not-implemented-hide:]
   // Specifies a set of URL query parameters on which the route should
   // match. The router will check the query string from the *path* header
   // against all the specified query parameters. If the number of specified


### PR DESCRIPTION
This diff unhides the docs now that the feature has been implemented in envoy.
Signed-off-by: Brian Pane <bpane@pinterest.com>