### PR TITLE
Fixing fix format

### DIFF
--- a/XDS_PROTOCOL.md
+++ b/XDS_PROTOCOL.md
@@ -123,10 +123,10 @@ server provides the same set of resources rather than waiting for a change to
 occur, it will cause Envoy and the management server to spin and have a severe
 performance impact.
 
-Within a stream, new `DiscoveryRequest`s supersede any prior `DiscoveryRequest`s 
-having the same resource type. This means that the management server only needs 
+Within a stream, new `DiscoveryRequest`s supersede any prior `DiscoveryRequest`s
+having the same resource type. This means that the management server only needs
 to respond to the latest `DiscoveryRequest` on each stream for any given resource
-type. 
+type.
 
 #### Resource hints
 

--- a/docs/root/api-v1/http_filters/squash_filter.rst
+++ b/docs/root/api-v1/http_filters/squash_filter.rst
@@ -23,13 +23,13 @@ cluster
 
 attachment_template
   *(required, object)* When the filter requests the Squash server to create a DebugAttachment, it
-  will use this structure as template for the body of the request. It can contain reference to 
+  will use this structure as template for the body of the request. It can contain reference to
   environment variables in the form of '{{ ENV_VAR_NAME }}'. These can be used to provide the Squash
   server with more information to find the process to attach the debugger to. For example, in a
   Istio/k8s environment, this will contain information on the pod:
 
   .. code-block:: json
-  
+
    {
      "spec": {
        "attachment": {
@@ -39,18 +39,18 @@ attachment_template
        "match_request": true
      }
    }
-  
+
   (where POD_NAME, POD_NAMESPACE are configured in the pod via the Downward API)
 
 request_timeout_ms
-  *(required, integer)* The timeout for individual requests sent to the Squash cluster. Defaults to 
+  *(required, integer)* The timeout for individual requests sent to the Squash cluster. Defaults to
   1 second.
 
 attachment_timeout_ms
-  *(required, integer)* The total timeout Squash will delay a request and wait for it to be 
+  *(required, integer)* The total timeout Squash will delay a request and wait for it to be
   attached. Defaults to 60 seconds.
 
 attachment_poll_period_ms
-  *(required, integer)* Amount of time to poll for the status of the attachment object in the Squash 
+  *(required, integer)* Amount of time to poll for the status of the attachment object in the Squash
   server (to check if has been attached). Defaults to 1 second.
 

--- a/docs/root/configuration/access_log.rst
+++ b/docs/root/configuration/access_log.rst
@@ -120,7 +120,7 @@ The following command operators are supported:
     <config_http_conn_man_headers_x-forwarded-for>`.
 
 %DOWNSTREAM_REMOTE_ADDRESS_WITHOUT_PORT%
-  Remote address of the downstream connection. If the address is an IP address the output does 
+  Remote address of the downstream connection. If the address is an IP address the output does
   *not* include port.
 
   .. note::

--- a/docs/root/configuration/http_conn_man/headers.rst
+++ b/docs/root/configuration/http_conn_man/headers.rst
@@ -301,7 +301,7 @@ Supported dynamic values are:
      This field is deprecated. Use **DOWNSTREAM_REMOTE_ADDRESS_WITHOUT_PORT** instead.
 
  %DOWNSTREAM_REMOTE_ADDRESS_WITHOUT_PORT%
-   Remote address of the downstream connection. If the address is an IP address the output does 
+   Remote address of the downstream connection. If the address is an IP address the output does
    *not* include port.
 
    .. note::

--- a/docs/root/configuration/http_filters/squash_filter.rst
+++ b/docs/root/configuration/http_filters/squash_filter.rst
@@ -14,7 +14,7 @@ Once a request marked for debugging enters the mesh, the Squash Envoy filter rep
 in the cluster to the Squash server - as there is a 1-1 mapping between Envoy sidecars and
 application containers, the Squash server can find and attach a debugger to the application container.
 The Squash filter also holds the request until a debugger is attached (or a timeout occurs). This
-enables developers (via Squash) to attach a native debugger to the container that will handle the 
+enables developers (via Squash) to attach a native debugger to the container that will handle the
 request, before the request arrive to the application code, without any changes to the cluster.
 
 Configuration

--- a/tools/check_format.py
+++ b/tools/check_format.py
@@ -33,17 +33,19 @@ def isBuildFile(file_path):
 def checkFileContents(file_path):
   with open(file_path) as f:
     text = f.read()
-    if re.search('[^.]\.  ', text, re.MULTILINE):
+    if (re.search('[^.]\.  ', text, re.MULTILINE) or
+        re.search(' $', text, re.MULTILINE)):
       printError("%s has over-enthusiastic spaces" % file_path)
       return False
   return True
 
 
 def fixFileContents(file_path):
+  regex = re.compile('([^.])\.  ')
   for line in fileinput.input(file_path, inplace=True):
     # Strip double space after '.'  This may prove overenthusiastic and need to
     # be restricted to comments and metadata files but works for now.
-    print "%s" % (line.replace('[^.].  ', '. ').rstrip())
+    print "%s" % regex.sub(r'\1. ', line).rstrip()
 
 
 def checkFilePath(file_path):


### PR DESCRIPTION
When I did the "ignoring tables" change I actually broke it :-(

Fixing with real python regex.  Also bonus complaining if there's trailing whitespace because otherwise fix_format fixes things check_format didn't whine about which results in files you didn't touch changing.