### PR TITLE
Add MetricsServiceConfig to bootstrap proto

### DIFF
--- a/api/bootstrap.proto
+++ b/api/bootstrap.proto
@@ -113,6 +113,10 @@ message Bootstrap {
 
   // Configuration for the local administration HTTP server.
   Admin admin = 12 [(validate.rules).message.required = true, (gogoproto.nullable) = false];
+
+  // Configuration for Metrics Service. If specified, Envoy will stream metrics
+  // to this service.
+  MetricsServiceConfig metrics_service = 14;
 }
 
 // Administration interface :ref:`operations documentation
@@ -211,5 +215,12 @@ message RateLimitServiceConfig {
   // Specifies the cluster manager cluster name that hosts the rate limit
   // service. The client will connect to this cluster when it needs to make rate
   // limit service requests.
+  string cluster_name = 1 [(validate.rules).string.min_bytes = 1];
+}
+
+// MetricsService Configuration structure.
+message MetricsServiceConfig {
+  // The name of the upstream cluster that hosts the metrics service. The cluster must be
+  // configured in the cluster manager.
   string cluster_name = 1 [(validate.rules).string.min_bytes = 1];
 }

--- a/api/metrics_service.proto
+++ b/api/metrics_service.proto
@@ -9,6 +9,8 @@ import "api/base.proto";
 import "google/api/annotations.proto";
 import "metrics.proto";
 
+import "validate/validate.proto";
+
 // Service for streaming metrics to server that consumes the metrics data. It uses Prometheus metric
 // data model as a standard to represent metrics information.
 service MetricsService {
@@ -23,8 +25,8 @@ message StreamMetricsResponse {
 
 message StreamMetricsMessage {
   message Identifier {
-    // The node sending the access log messages over the stream.
-    Node node = 1;
+    // The node sending metrics over the stream.
+    Node node = 1 [(validate.rules).message.required = true];
   }
 
   // Identifier data effectively is a structured metadata.
@@ -39,5 +41,5 @@ message StreamMetricsMessage {
 message MetricsServiceConfig {
   // The name of the upstream cluster that hosts the metrics service. The cluster must be
   // configured in the cluster manager.
-  string cluster_name = 1;
+  string cluster_name = 1 [(validate.rules).string.min_bytes = 1];
 }

--- a/api/metrics_service.proto
+++ b/api/metrics_service.proto
@@ -36,10 +36,3 @@ message StreamMetricsMessage {
   // A list of metric entries
   repeated io.prometheus.client.MetricFamily envoy_metrics = 2;
 }
-
-// Configuration structure.
-message MetricsServiceConfig {
-  // The name of the upstream cluster that hosts the metrics service. The cluster must be
-  // configured in the cluster manager.
-  string cluster_name = 1 [(validate.rules).string.min_bytes = 1];
-}


### PR DESCRIPTION
Add MetricsServiceConfig to bootstrap proto, so that it's cluster can be configured.