### PR TITLE
Add an option to forward the base64 encoded cert through the xfcc header

### DIFF
--- a/api/filter/network/http_connection_manager.proto
+++ b/api/filter/network/http_connection_manager.proto
@@ -169,6 +169,10 @@ message HttpConnectionManager {
 
     // Whether to forward the SAN of the client cert. Defaults to false.
     google.protobuf.BoolValue san = 2;
+
+    // [#not-implemented-hide:]
+    // Whether to forward the entire client cert in base64 encoded format. Defaults to false.
+    bool cert = 3;
   };
 
   // This field is valid only when :ref:`forward_client_cert_details


### PR DESCRIPTION
I have a pull request ready for Envoy as well that I could submit without tests until this gets merged and I can add end to end integration tests.  This is also my first contribution to envoy, but I didn't see any mention of a need to sign a CLA but am happy to do so if required.