### PR TITLE
cds: Add "auto_http2" option.

### DIFF
--- a/api/cds.proto
+++ b/api/cds.proto
@@ -415,6 +415,13 @@ message Cluster {
   // For instance, if the metadata is intended for the Router filter, the filter
   // name should be specified as *envoy.router*.
   Metadata metadata = 25;
+
+  enum ClusterProtocolSelection {
+    // Cluster can only operate on one of the possible upstream protocols (HTTP1.1, HTTP2).
+    // If http2_protocol_options are present, HTTP2 will be used, otherwise HTTP1.1 will be used.
+    EXCLUSIVE_AS_CONFIGURED = 0;
+  }
+  ClusterProtocolSelection protocol_selection = 26;
 }
 
 // An extensible structure containing the address Envoy should bind to when

--- a/api/cds.proto
+++ b/api/cds.proto
@@ -421,7 +421,7 @@ message Cluster {
     // If http2_protocol_options are present, HTTP2 will be used, otherwise HTTP1.1 will be used.
     EXCLUSIVE_AS_CONFIGURED = 0;
     // Use HTTP1.1 or HTTP2, depending on which one is used on the downstream connection.
-    USE_DOWNSTREAM_PROTO = 1;
+    USE_DOWNSTREAM_PROTOCOL = 1;
   }
   ClusterProtocolSelection protocol_selection = 26;
 }

--- a/api/cds.proto
+++ b/api/cds.proto
@@ -419,7 +419,7 @@ message Cluster {
   Metadata metadata = 25;
 
   // Cluster can operate both HTTP1.1 and HTTP2 connections and the protocol
-  // is chosen based on the downstream protocol, if any.  In case there is no
+  // is chosen based on the downstream protocol, if any. In case there is no
   // downstream connection, this option will be ignored.
   bool auto_http2 = 26;
 }

--- a/api/cds.proto
+++ b/api/cds.proto
@@ -161,24 +161,22 @@ message Cluster {
   //   verification.
   UpstreamTlsContext tls_context = 11;
 
-  oneof protocol_options {
-    // [#not-implemented-hide:]
-    TcpProtocolOptions tcp_protocol_options = 12;
+  // [#not-implemented-hide:]
+  TcpProtocolOptions tcp_protocol_options = 12;
 
-    // Additional options when handling HTTP1 requests.
-    Http1ProtocolOptions http_protocol_options = 13;
+  // Additional options when handling HTTP1 requests.
+  Http1ProtocolOptions http_protocol_options = 13;
 
-    // Even if default HTTP2 protocol options are desired, this field must be
-    // set so that Envoy will assume that the upstream supports HTTP/2 when
-    // making new HTTP connection pool connections. Currently, Envoy only
-    // supports prior knowledge for upstream connections. Even if TLS is used
-    // with ALPN, `http2_protocol_options` must be specified. As an aside this allows HTTP/2
-    // connections to happen over plain text.
-    Http2ProtocolOptions http2_protocol_options = 14;
+  // Even if default HTTP2 protocol options are desired, this field must be
+  // set so that Envoy will assume that the upstream supports HTTP/2 when
+  // making new HTTP connection pool connections. Currently, Envoy only
+  // supports prior knowledge for upstream connections. Even if TLS is used
+  // with ALPN, `http2_protocol_options` must be specified. As an aside this allows HTTP/2
+  // connections to happen over plain text.
+  Http2ProtocolOptions http2_protocol_options = 14;
 
-    // [#not-implemented-hide:]
-    GrpcProtocolOptions grpc_protocol_options = 15;
-  }
+  // [#not-implemented-hide:]
+  GrpcProtocolOptions grpc_protocol_options = 15;
 
   // If the DNS refresh rate is specified and the cluster type is either
   // :ref:`STRICT_DNS<envoy_api_enum_value_Cluster.DiscoveryType.STRICT_DNS>`,
@@ -417,11 +415,6 @@ message Cluster {
   // For instance, if the metadata is intended for the Router filter, the filter
   // name should be specified as *envoy.router*.
   Metadata metadata = 25;
-
-  // Cluster can operate both HTTP1.1 and HTTP2 connections and the protocol
-  // is chosen based on the downstream protocol, if any. In case there is no
-  // downstream connection, this option will be ignored.
-  bool auto_http2 = 26;
 }
 
 // An extensible structure containing the address Envoy should bind to when

--- a/api/cds.proto
+++ b/api/cds.proto
@@ -417,6 +417,11 @@ message Cluster {
   // For instance, if the metadata is intended for the Router filter, the filter
   // name should be specified as *envoy.router*.
   Metadata metadata = 25;
+
+  // Cluster can operate both HTTP1.1 and HTTP2 connections and the protocol
+  // is chosen based on the downstream protocol, if any.  In case there is no
+  // downstream connection, this option will be ignored.
+  bool auto_http2 = 26;
 }
 
 // An extensible structure containing the address Envoy should bind to when

--- a/api/cds.proto
+++ b/api/cds.proto
@@ -420,6 +420,8 @@ message Cluster {
     // Cluster can only operate on one of the possible upstream protocols (HTTP1.1, HTTP2).
     // If http2_protocol_options are present, HTTP2 will be used, otherwise HTTP1.1 will be used.
     EXCLUSIVE_AS_CONFIGURED = 0;
+    // Use HTTP1.1 or HTTP2, depending on which one is used on the downstream connection.
+    USE_DOWNSTREAM_PROTO = 1;
   }
   ClusterProtocolSelection protocol_selection = 26;
 }

--- a/api/cds.proto
+++ b/api/cds.proto
@@ -161,9 +161,6 @@ message Cluster {
   //   verification.
   UpstreamTlsContext tls_context = 11;
 
-  // [#not-implemented-hide:]
-  TcpProtocolOptions tcp_protocol_options = 12;
-
   // Additional options when handling HTTP1 requests.
   Http1ProtocolOptions http_protocol_options = 13;
 
@@ -174,9 +171,6 @@ message Cluster {
   // with ALPN, `http2_protocol_options` must be specified. As an aside this allows HTTP/2
   // connections to happen over plain text.
   Http2ProtocolOptions http2_protocol_options = 14;
-
-  // [#not-implemented-hide:]
-  GrpcProtocolOptions grpc_protocol_options = 15;
 
   // If the DNS refresh rate is specified and the cluster type is either
   // :ref:`STRICT_DNS<envoy_api_enum_value_Cluster.DiscoveryType.STRICT_DNS>`,

--- a/api/cds.proto
+++ b/api/cds.proto
@@ -161,7 +161,7 @@ message Cluster {
   //   verification.
   UpstreamTlsContext tls_context = 11;
 
-  // deleted = 12;
+  reserved 12;
 
   // Additional options when handling HTTP1 requests.
   Http1ProtocolOptions http_protocol_options = 13;
@@ -174,7 +174,7 @@ message Cluster {
   // connections to happen over plain text.
   Http2ProtocolOptions http2_protocol_options = 14;
 
-  // deleted = 15;
+  reserved 15;
 
   // If the DNS refresh rate is specified and the cluster type is either
   // :ref:`STRICT_DNS<envoy_api_enum_value_Cluster.DiscoveryType.STRICT_DNS>`,
@@ -418,7 +418,7 @@ message Cluster {
     // Cluster can only operate on one of the possible upstream protocols (HTTP1.1, HTTP2).
     // If :ref:`http2_protocol_options <envoy_api_field_Cluster.http2_protocol_options>` are
     // present, HTTP2 will be used, otherwise HTTP1.1 will be used.
-    EXCLUSIVE_AS_CONFIGURED = 0;
+    USE_CONFIGURED_PROTOCOL = 0;
     // Use HTTP1.1 or HTTP2, depending on which one is used on the downstream connection.
     USE_DOWNSTREAM_PROTOCOL = 1;
   }

--- a/api/cds.proto
+++ b/api/cds.proto
@@ -412,7 +412,8 @@ message Cluster {
 
   enum ClusterProtocolSelection {
     // Cluster can only operate on one of the possible upstream protocols (HTTP1.1, HTTP2).
-    // If http2_protocol_options are present, HTTP2 will be used, otherwise HTTP1.1 will be used.
+    // If :ref:`http2_protocol_options <envoy_api_field_Cluster.http2_protocol_options>` are
+    // present, HTTP2 will be used, otherwise HTTP1.1 will be used.
     EXCLUSIVE_AS_CONFIGURED = 0;
     // Use HTTP1.1 or HTTP2, depending on which one is used on the downstream connection.
     USE_DOWNSTREAM_PROTOCOL = 1;

--- a/api/cds.proto
+++ b/api/cds.proto
@@ -161,6 +161,8 @@ message Cluster {
   //   verification.
   UpstreamTlsContext tls_context = 11;
 
+  // deleted = 12;
+  
   // Additional options when handling HTTP1 requests.
   Http1ProtocolOptions http_protocol_options = 13;
 
@@ -172,6 +174,8 @@ message Cluster {
   // connections to happen over plain text.
   Http2ProtocolOptions http2_protocol_options = 14;
 
+  // deleted = 15;
+  
   // If the DNS refresh rate is specified and the cluster type is either
   // :ref:`STRICT_DNS<envoy_api_enum_value_Cluster.DiscoveryType.STRICT_DNS>`,
   // or :ref:`LOGICAL_DNS<envoy_api_enum_value_Cluster.DiscoveryType.LOGICAL_DNS>`,

--- a/api/cds.proto
+++ b/api/cds.proto
@@ -162,7 +162,7 @@ message Cluster {
   UpstreamTlsContext tls_context = 11;
 
   // deleted = 12;
-  
+
   // Additional options when handling HTTP1 requests.
   Http1ProtocolOptions http_protocol_options = 13;
 
@@ -175,7 +175,7 @@ message Cluster {
   Http2ProtocolOptions http2_protocol_options = 14;
 
   // deleted = 15;
-  
+
   // If the DNS refresh rate is specified and the cluster type is either
   // :ref:`STRICT_DNS<envoy_api_enum_value_Cluster.DiscoveryType.STRICT_DNS>`,
   // or :ref:`LOGICAL_DNS<envoy_api_enum_value_Cluster.DiscoveryType.LOGICAL_DNS>`,


### PR DESCRIPTION
Currently clusters can not open both HTTP1.1 and HTTP2 upstream
connections at the same time.  When the new cluster option
"auto_http2" is set to "true", the cluster must open an HTTP2 upstream
connection if the downstream connection is HTTP2, and an HTTP1.1
upstream connection if the downstream connection is HTTP1.1. This option
is to have no effect if there is no corresponding downstream
connection.

This functionality removes the need to operate multiple clusters and
routing rules for them when the backends accept both HTTP1.1 and HTTP2
connections, and when the choice of the HTTP protocol is significant,
as with gRPC.

Signed-off-by: Jarno Rajahalme <jarno@covalent.io>