### PR TITLE
Use upper camel case names for type names

### DIFF
--- a/STYLE.md
+++ b/STYLE.md
@@ -19,12 +19,15 @@ In addition, the following conventions should be followed:
 * Use [wrapped scalar
   types](https://github.com/google/protobuf/blob/master/src/google/protobuf/wrappers.proto)
   where there is a real need for the field to have a default value that does not
-  match the proto3 default (0/false/""). This should not be done for fields
+  match the proto3 defaults (0/false/""). This should not be done for fields
   where the proto3 defaults make sense. All things being equal, pick appropriate
   logic, e.g. enable vs. disable for a `bool` field, such that the proto3
   defaults work, but only where this doesn't result in API gymnastics.
 
-* Always use plural field names for `repeated` fields.
+* Always use plural field names for `repeated` fields, such as `filters`.
+
+* Always use upper camel case names for message types and enum types without embedded
+  acronyms, such as `HttpRequest`.
 
 * Prefer `oneof` selections to boolean overloads of fields, for example, prefer:
 


### PR DESCRIPTION
This is a common disagreement within existing APIs. We should avoid this issue.

Signed-off-by: Hong Zhang <wora2000@gmail.com>