### PR TITLE
Docs: add notice related to lua and exported symbols

### DIFF
--- a/docs/root/configuration/http_filters/lua_filter.rst
+++ b/docs/root/configuration/http_filters/lua_filter.rst
@@ -10,6 +10,12 @@ Lua
   and verification. This warning will be removed when we feel that the filter has received enough
   testing and API stability to call it generally production ready.
 
+.. attention::
+
+  By default envoy is built without exporting symbols that you may need when interacting with
+  lua modules installed as shared objects.  If may need to build envoy with support for exported symbols.
+  Please see the `bazel docs <https://github.com/envoyproxy/envoy/blob/master/bazel/README.md>` for more information.
+
 Overview
 --------
 


### PR DESCRIPTION
I've added a notice to the lua filter related to how it's built and linked and that a user wishing to load modules installed with luarocks would need to build envoy with exported symbols.

Signed-off-by: Nicholas J nicholas.a.johns5@gmail.com