### PR TITLE
Refactor go BUILD targets.

### DIFF
--- a/api/BUILD
+++ b/api/BUILD
@@ -1,5 +1,4 @@
-load("//bazel:api_build_system.bzl", "api_proto_library")
-load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library", "go_grpc_library")
+load("//bazel:api_build_system.bzl", "api_proto_library", "api_go_proto_library", "api_go_grpc_library")
 
 licenses(["notice"])  # Apache 2
 
@@ -8,11 +7,9 @@ api_proto_library(
     srcs = ["address.proto"],
 )
 
-go_proto_library(
-    name = "address_go_proto",
+api_go_proto_library(
     importpath = "github.com/envoyproxy/data-plane-api/api/address",
-    proto = ":address",
-    visibility = ["//visibility:public"],
+    proto = "address",
     deps = [
         "@com_github_gogo_protobuf//:gogo_proto_go",
         "@com_github_golang_protobuf//ptypes/wrappers:go_default_library",
@@ -26,11 +23,9 @@ api_proto_library(
     deps = [":address"],
 )
 
-go_proto_library(
-    name = "base_go_proto",
+api_go_proto_library(
     importpath = "github.com/envoyproxy/data-plane-api/api/base",
-    proto = ":base",
-    visibility = ["//visibility:public"],
+    proto = "base",
     deps = [
         ":address_go_proto",
         "@com_github_gogo_protobuf//:gogo_proto_go",
@@ -57,11 +52,9 @@ api_proto_library(
     ],
 )
 
-go_proto_library(
-    name = "bootstrap_go_proto",
+api_go_proto_library(
     importpath = "github.com/envoyproxy/data-plane-api/api/bootstrap",
-    proto = ":bootstrap",
-    visibility = ["//visibility:public"],
+    proto = "bootstrap",
     deps = [
         ":address_go_proto",
         ":base_go_proto",
@@ -84,11 +77,9 @@ api_proto_library(
     deps = [":base"],
 )
 
-go_proto_library(
-    name = "health_check_go_proto",
+api_go_proto_library(
     importpath = "github.com/envoyproxy/data-plane-api/api/health_check",
-    proto = ":health_check",
-    visibility = ["//visibility:public"],
+    proto = "health_check",
     deps = [
         ":base_go_proto",
         "@com_github_golang_protobuf//ptypes/duration:go_default_library",
@@ -112,11 +103,9 @@ api_proto_library(
     ],
 )
 
-go_grpc_library(
-    name = "cds_go_grpc",
+api_go_grpc_library(
     importpath = "github.com/envoyproxy/data-plane-api/api/cds",
-    proto = ":cds",
-    visibility = ["//visibility:public"],
+    proto = "cds",
     deps = [
         ":address_go_proto",
         ":base_go_proto",
@@ -143,11 +132,9 @@ api_proto_library(
     ],
 )
 
-go_proto_library(
-    name = "config_source_go_proto",
+api_go_proto_library(
     importpath = "github.com/envoyproxy/data-plane-api/api/config_source",
-    proto = ":config_source",
-    visibility = ["//visibility:public"],
+    proto = "config_source",
     deps = [
         ":base_go_proto",
         ":grpc_service_go_proto",
@@ -164,11 +151,9 @@ api_proto_library(
     deps = [":base"],
 )
 
-go_grpc_library(
-    name = "discovery_go_grpc",
+api_go_grpc_library(
     importpath = "github.com/envoyproxy/data-plane-api/api/discovery",
-    proto = ":discovery",
-    visibility = ["//visibility:public"],
+    proto = "discovery",
     deps = [
         ":base_go_proto",
         "@com_github_golang_protobuf//ptypes/any:go_default_library",
@@ -187,11 +172,9 @@ api_proto_library(
     ],
 )
 
-go_grpc_library(
-    name = "eds_go_grpc",
+api_go_grpc_library(
     importpath = "github.com/envoyproxy/data-plane-api/api/eds",
-    proto = ":eds",
-    visibility = ["//visibility:public"],
+    proto = "eds",
     deps = [
         ":address_go_proto",
         ":base_go_proto",
@@ -210,11 +193,9 @@ api_proto_library(
     deps = [":base"],
 )
 
-go_proto_library(
-    name = "grpc_service_go_proto",
+api_go_proto_library(
     importpath = "github.com/envoyproxy/data-plane-api/api/grpc_service",
-    proto = ":grpc_service",
-    visibility = ["//visibility:public"],
+    proto = "grpc_service",
     deps = [
         ":base_go_proto",
         "@com_github_golang_protobuf//ptypes/duration:go_default_library",
@@ -232,11 +213,9 @@ api_proto_library(
     ],
 )
 
-go_grpc_library(
-    name = "hds_go_grpc",
+api_go_grpc_library(
     importpath = "github.com/envoyproxy/data-plane-api/api/hds",
-    proto = ":hds",
-    visibility = ["//visibility:public"],
+    proto = "hds",
     deps = [
         ":base_go_proto",
         ":health_check_go_proto",
@@ -257,11 +236,9 @@ api_proto_library(
     ],
 )
 
-go_grpc_library(
-    name = "lds_go_grpc",
+api_go_grpc_library(
     importpath = "github.com/envoyproxy/data-plane-api/api/lds",
-    proto = ":lds",
-    visibility = ["//visibility:public"],
+    proto = "lds",
     deps = [
         ":address_go_proto",
         ":base_go_proto",
@@ -291,11 +268,9 @@ api_proto_library(
     srcs = ["protocol.proto"],
 )
 
-go_proto_library(
-    name = "protocol_go_proto",
+api_go_proto_library(
     importpath = "github.com/envoyproxy/data-plane-api/api/protocol",
-    proto = ":protocol",
-    visibility = ["//visibility:public"],
+    proto = "protocol",
     deps = [
         "@com_github_golang_protobuf//ptypes/wrappers:go_default_library",
         "@com_lyft_protoc_gen_validate//validate:go_default_library",
@@ -308,11 +283,9 @@ api_proto_library(
     has_services = 1,
 )
 
-go_grpc_library(
-    name = "rls_go_grpc",
+api_go_grpc_library(
     importpath = "github.com/envoyproxy/data-plane-api/api/rls",
-    proto = ":rls",
-    visibility = ["//visibility:public"],
+    proto = "rls",
     deps = [
         "@com_lyft_protoc_gen_validate//validate:go_default_library",
     ],
@@ -329,11 +302,9 @@ api_proto_library(
     ],
 )
 
-go_grpc_library(
-    name = "rds_go_grpc",
+api_go_grpc_library(
     importpath = "github.com/envoyproxy/data-plane-api/api/rds",
-    proto = ":rds",
-    visibility = ["//visibility:public"],
+    proto = "rds",
     deps = [
         ":auth_go_proto",
         ":base_go_proto",
@@ -357,11 +328,9 @@ api_proto_library(
     ],
 )
 
-go_grpc_library(
-    name = "sds_go_grpc",
+api_go_grpc_library(
     importpath = "github.com/envoyproxy/data-plane-api/api/sds",
-    proto = ":sds",
-    visibility = ["//visibility:public"],
+    proto = "sds",
     deps = [
         ":base_go_proto",
         ":config_source_go_proto",
@@ -380,11 +349,9 @@ api_proto_library(
     ],
 )
 
-go_proto_library(
-    name = "stats_go_proto",
+api_go_proto_library(
     importpath = "github.com/envoyproxy/data-plane-api/api/stats",
-    proto = ":stats",
-    visibility = ["//visibility:public"],
+    proto = "stats",
     deps = [
         ":address_go_proto",
         "@com_github_golang_protobuf//ptypes/struct:go_default_library",
@@ -398,11 +365,9 @@ api_proto_library(
     srcs = ["trace.proto"],
 )
 
-go_proto_library(
-    name = "trace_go_proto",
+api_go_proto_library(
     importpath = "github.com/envoyproxy/data-plane-api/api/trace",
-    proto = ":trace",
-    visibility = ["//visibility:public"],
+    proto = "trace",
     deps = [
         "@com_github_golang_protobuf//ptypes/struct:go_default_library",
         "@com_lyft_protoc_gen_validate//validate:go_default_library",
@@ -417,11 +382,9 @@ api_proto_library(
     ],
 )
 
-go_proto_library(
-    name = "auth_go_proto",
+api_go_proto_library(
     importpath = "github.com/envoyproxy/data-plane-api/auth",
-    proto = ":auth",
-    visibility = ["//visibility:public"],
+    proto = "auth",
     deps = [
         "//api:address_go_proto",
         "//api:sds_go_grpc",

--- a/api/BUILD
+++ b/api/BUILD
@@ -8,13 +8,8 @@ api_proto_library(
 )
 
 api_go_proto_library(
-    importpath = "github.com/envoyproxy/data-plane-api/api/address",
-    proto = "address",
-    deps = [
-        "@com_github_gogo_protobuf//:gogo_proto_go",
-        "@com_github_golang_protobuf//ptypes/wrappers:go_default_library",
-        "@com_lyft_protoc_gen_validate//validate:go_default_library",
-    ],
+    name = "address",
+    proto = ":address",
 )
 
 api_proto_library(
@@ -24,16 +19,9 @@ api_proto_library(
 )
 
 api_go_proto_library(
-    importpath = "github.com/envoyproxy/data-plane-api/api/base",
-    proto = "base",
-    deps = [
-        ":address_go_proto",
-        "@com_github_gogo_protobuf//:gogo_proto_go",
-        "@com_github_golang_protobuf//ptypes/duration:go_default_library",
-        "@com_github_golang_protobuf//ptypes/struct:go_default_library",
-        "@com_github_golang_protobuf//ptypes/wrappers:go_default_library",
-        "@com_lyft_protoc_gen_validate//validate:go_default_library",
-    ],
+    name = "base",
+    proto = ":base",
+    deps = [":address_go_proto"],
 )
 
 api_proto_library(
@@ -53,8 +41,8 @@ api_proto_library(
 )
 
 api_go_proto_library(
-    importpath = "github.com/envoyproxy/data-plane-api/api/bootstrap",
-    proto = "bootstrap",
+    name = "bootstrap",
+    proto = ":bootstrap",
     deps = [
         ":address_go_proto",
         ":base_go_proto",
@@ -65,9 +53,6 @@ api_go_proto_library(
         ":sds_go_grpc",
         ":stats_go_proto",
         ":trace_go_proto",
-        "@com_github_gogo_protobuf//:gogo_proto_go",
-        "@com_github_golang_protobuf//ptypes/duration:go_default_library",
-        "@com_lyft_protoc_gen_validate//validate:go_default_library",
     ],
 )
 
@@ -78,14 +63,9 @@ api_proto_library(
 )
 
 api_go_proto_library(
-    importpath = "github.com/envoyproxy/data-plane-api/api/health_check",
-    proto = "health_check",
-    deps = [
-        ":base_go_proto",
-        "@com_github_golang_protobuf//ptypes/duration:go_default_library",
-        "@com_github_golang_protobuf//ptypes/wrappers:go_default_library",
-        "@com_lyft_protoc_gen_validate//validate:go_default_library",
-    ],
+    name = "health_check",
+    proto = ":health_check",
+    deps = [":base_go_proto"],
 )
 
 api_proto_library(
@@ -104,8 +84,8 @@ api_proto_library(
 )
 
 api_go_grpc_library(
-    importpath = "github.com/envoyproxy/data-plane-api/api/cds",
-    proto = "cds",
+    name = "cds",
+    proto = ":cds",
     deps = [
         ":address_go_proto",
         ":base_go_proto",
@@ -114,12 +94,6 @@ api_go_grpc_library(
         ":health_check_go_proto",
         ":protocol_go_proto",
         ":sds_go_grpc",
-        "@com_github_gogo_protobuf//:gogo_proto_go",
-        "@com_github_golang_protobuf//ptypes/duration:go_default_library",
-        "@com_github_golang_protobuf//ptypes/struct:go_default_library",
-        "@com_github_golang_protobuf//ptypes/wrappers:go_default_library",
-        "@com_lyft_protoc_gen_validate//validate:go_default_library",
-        "@googleapis//:http_api_go_proto",
     ],
 )
 
@@ -133,14 +107,11 @@ api_proto_library(
 )
 
 api_go_proto_library(
-    importpath = "github.com/envoyproxy/data-plane-api/api/config_source",
-    proto = "config_source",
+    name = "config_source",
+    proto = ":config_source",
     deps = [
         ":base_go_proto",
         ":grpc_service_go_proto",
-        "@com_github_gogo_protobuf//:gogo_proto_go",
-        "@com_github_golang_protobuf//ptypes/duration:go_default_library",
-        "@com_lyft_protoc_gen_validate//validate:go_default_library",
     ],
 )
 
@@ -152,12 +123,9 @@ api_proto_library(
 )
 
 api_go_grpc_library(
-    importpath = "github.com/envoyproxy/data-plane-api/api/discovery",
-    proto = "discovery",
-    deps = [
-        ":base_go_proto",
-        "@com_github_golang_protobuf//ptypes/any:go_default_library",
-    ],
+    name = "discovery",
+    proto = ":discovery",
+    deps = [":base_go_proto"],
 )
 
 api_proto_library(
@@ -173,17 +141,13 @@ api_proto_library(
 )
 
 api_go_grpc_library(
-    importpath = "github.com/envoyproxy/data-plane-api/api/eds",
-    proto = "eds",
+    name = "eds",
+    proto = ":eds",
     deps = [
         ":address_go_proto",
         ":base_go_proto",
         ":discovery_go_grpc",
         ":health_check_go_proto",
-        "@com_github_golang_protobuf//ptypes/duration:go_default_library",
-        "@com_github_golang_protobuf//ptypes/wrappers:go_default_library",
-        "@com_lyft_protoc_gen_validate//validate:go_default_library",
-        "@googleapis//:http_api_go_proto",
     ],
 )
 
@@ -194,13 +158,9 @@ api_proto_library(
 )
 
 api_go_proto_library(
-    importpath = "github.com/envoyproxy/data-plane-api/api/grpc_service",
-    proto = "grpc_service",
-    deps = [
-        ":base_go_proto",
-        "@com_github_golang_protobuf//ptypes/duration:go_default_library",
-        "@com_lyft_protoc_gen_validate//validate:go_default_library",
-    ],
+    name = "grpc_service",
+    proto = ":grpc_service",
+    deps = [":base_go_proto"],
 )
 
 api_proto_library(
@@ -214,13 +174,11 @@ api_proto_library(
 )
 
 api_go_grpc_library(
-    importpath = "github.com/envoyproxy/data-plane-api/api/hds",
-    proto = "hds",
+    name = "hds",
+    proto = ":hds",
     deps = [
         ":base_go_proto",
         ":health_check_go_proto",
-        "@com_github_golang_protobuf//ptypes/duration:go_default_library",
-        "@googleapis//:http_api_go_proto",
     ],
 )
 
@@ -237,17 +195,13 @@ api_proto_library(
 )
 
 api_go_grpc_library(
-    importpath = "github.com/envoyproxy/data-plane-api/api/lds",
-    proto = "lds",
+    name = "lds",
+    proto = ":lds",
     deps = [
         ":address_go_proto",
         ":base_go_proto",
         ":discovery_go_grpc",
         ":sds_go_grpc",
-        "@com_github_golang_protobuf//ptypes/struct:go_default_library",
-        "@com_github_golang_protobuf//ptypes/wrappers:go_default_library",
-        "@com_lyft_protoc_gen_validate//validate:go_default_library",
-        "@googleapis//:http_api_go_proto",
     ],
 )
 
@@ -269,12 +223,8 @@ api_proto_library(
 )
 
 api_go_proto_library(
-    importpath = "github.com/envoyproxy/data-plane-api/api/protocol",
-    proto = "protocol",
-    deps = [
-        "@com_github_golang_protobuf//ptypes/wrappers:go_default_library",
-        "@com_lyft_protoc_gen_validate//validate:go_default_library",
-    ],
+    name = "protocol",
+    proto = ":protocol",
 )
 
 api_proto_library(
@@ -284,11 +234,8 @@ api_proto_library(
 )
 
 api_go_grpc_library(
-    importpath = "github.com/envoyproxy/data-plane-api/api/rls",
-    proto = "rls",
-    deps = [
-        "@com_lyft_protoc_gen_validate//validate:go_default_library",
-    ],
+    name = "rls",
+    proto = ":rls",
 )
 
 api_proto_library(
@@ -303,17 +250,12 @@ api_proto_library(
 )
 
 api_go_grpc_library(
-    importpath = "github.com/envoyproxy/data-plane-api/api/rds",
-    proto = "rds",
+    name = "rds",
+    proto = ":rds",
     deps = [
         ":auth_go_proto",
         ":base_go_proto",
         ":discovery_go_grpc",
-        "@com_github_gogo_protobuf//:gogo_proto_go",
-        "@com_github_golang_protobuf//ptypes/duration:go_default_library",
-        "@com_github_golang_protobuf//ptypes/wrappers:go_default_library",
-        "@com_lyft_protoc_gen_validate//validate:go_default_library",
-        "@googleapis//:http_api_go_proto",
     ],
 )
 
@@ -329,15 +271,12 @@ api_proto_library(
 )
 
 api_go_grpc_library(
-    importpath = "github.com/envoyproxy/data-plane-api/api/sds",
-    proto = "sds",
+    name = "sds",
+    proto = ":sds",
     deps = [
         ":base_go_proto",
         ":config_source_go_proto",
         ":discovery_go_grpc",
-        "@com_github_golang_protobuf//ptypes/wrappers:go_default_library",
-        "@com_lyft_protoc_gen_validate//validate:go_default_library",
-        "@googleapis//:http_api_go_proto",
     ],
 )
 
@@ -350,13 +289,10 @@ api_proto_library(
 )
 
 api_go_proto_library(
-    importpath = "github.com/envoyproxy/data-plane-api/api/stats",
-    proto = "stats",
+    name = "stats",
+    proto = ":stats",
     deps = [
         ":address_go_proto",
-        "@com_github_golang_protobuf//ptypes/struct:go_default_library",
-        "@com_github_golang_protobuf//ptypes/wrappers:go_default_library",
-        "@com_lyft_protoc_gen_validate//validate:go_default_library",
     ],
 )
 
@@ -366,12 +302,8 @@ api_proto_library(
 )
 
 api_go_proto_library(
-    importpath = "github.com/envoyproxy/data-plane-api/api/trace",
-    proto = "trace",
-    deps = [
-        "@com_github_golang_protobuf//ptypes/struct:go_default_library",
-        "@com_lyft_protoc_gen_validate//validate:go_default_library",
-    ],
+    name = "trace",
+    proto = ":trace",
 )
 
 api_proto_library(
@@ -383,13 +315,11 @@ api_proto_library(
 )
 
 api_go_proto_library(
-    importpath = "github.com/envoyproxy/data-plane-api/auth",
-    proto = "auth",
+    name = "auth",
+    proto = ":auth",
     deps = [
         "//api:address_go_proto",
         "//api:sds_go_grpc",
-        "@com_github_golang_protobuf//ptypes/struct:go_default_library",
-        "@com_github_golang_protobuf//ptypes/timestamp:go_default_library",
         "@googleapis//:rpc_status_go_proto",
     ],
 )

--- a/bazel/api_build_system.bzl
+++ b/bazel/api_build_system.bzl
@@ -1,8 +1,12 @@
 load("@com_google_protobuf//:protobuf.bzl", "py_proto_library")
 load("@com_lyft_protoc_gen_validate//bazel:pgv_proto_library.bzl", "pgv_cc_proto_library")
+load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library", "go_grpc_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_test")
 
 _PY_SUFFIX="_py"
 _CC_SUFFIX="_cc"
+_GO_PROTO_SUFFIX="_go_proto"
+_GO_GRPC_SUFFIX="_go_grpc"
 
 def _Suffix(d, suffix):
   return d + suffix
@@ -32,6 +36,24 @@ def api_py_proto_library(name, srcs = [], deps = [], has_services = 0):
             "@com_github_gogo_protobuf//:gogo_proto_py",
         ],
         visibility = ["//visibility:public"],
+    )
+
+def api_go_proto_library(proto, importpath, deps = []):
+    go_proto_library(
+        name = _Suffix(proto, _GO_PROTO_SUFFIX),
+        importpath = importpath,
+        proto = _Suffix(":", proto),
+        visibility = ["//visibility:public"],
+        deps = deps,
+    )
+
+def api_go_grpc_library(proto, importpath, deps = []):
+    go_grpc_library(
+        name = _Suffix(proto, _GO_GRPC_SUFFIX),
+        importpath = importpath,
+        proto = _Suffix(":", proto),
+        visibility = ["//visibility:public"],
+        deps = deps,
     )
 
 # TODO(htuch): has_services is currently ignored but will in future support
@@ -86,4 +108,13 @@ def api_cc_test(name, srcs, proto_deps):
         name = name,
         srcs = srcs,
         deps = [_LibrarySuffix(d, _CC_SUFFIX) for d in proto_deps],
+    )
+
+def api_go_test(name, size, importpath, srcs = [], deps = []):
+    go_test(
+        name = name,
+        size = size,
+        srcs = srcs,
+        importpath = importpath,
+        deps = deps,
     )

--- a/bazel/api_build_system.bzl
+++ b/bazel/api_build_system.bzl
@@ -7,6 +7,7 @@ _PY_SUFFIX="_py"
 _CC_SUFFIX="_cc"
 _GO_PROTO_SUFFIX="_go_proto"
 _GO_GRPC_SUFFIX="_go_grpc"
+_GO_IMPORTPATH_PREFIX="github.com/envoyproxy/data-plane-api/api/"
 
 def _Suffix(d, suffix):
   return d + suffix
@@ -38,22 +39,37 @@ def api_py_proto_library(name, srcs = [], deps = [], has_services = 0):
         visibility = ["//visibility:public"],
     )
 
-def api_go_proto_library(proto, importpath, deps = []):
+def api_go_proto_library(name, proto, deps = []):
     go_proto_library(
-        name = _Suffix(proto, _GO_PROTO_SUFFIX),
-        importpath = importpath,
-        proto = _Suffix(":", proto),
+        name = _Suffix(name, _GO_PROTO_SUFFIX),
+        importpath = _Suffix(_GO_IMPORTPATH_PREFIX, name),
+        proto = proto,
         visibility = ["//visibility:public"],
-        deps = deps,
+        deps = deps + [
+            "@com_github_gogo_protobuf//:gogo_proto_go",
+            "@com_github_golang_protobuf//ptypes/duration:go_default_library",
+            "@com_github_golang_protobuf//ptypes/struct:go_default_library",
+            "@com_github_golang_protobuf//ptypes/timestamp:go_default_library",
+            "@com_github_golang_protobuf//ptypes/wrappers:go_default_library",
+            "@com_lyft_protoc_gen_validate//validate:go_default_library",
+        ]
     )
 
-def api_go_grpc_library(proto, importpath, deps = []):
+def api_go_grpc_library(name, proto, deps = []):
     go_grpc_library(
-        name = _Suffix(proto, _GO_GRPC_SUFFIX),
-        importpath = importpath,
-        proto = _Suffix(":", proto),
+        name = _Suffix(name, _GO_GRPC_SUFFIX),
+        importpath = _Suffix(_GO_IMPORTPATH_PREFIX, name),
+        proto = proto,
         visibility = ["//visibility:public"],
-        deps = deps,
+        deps = deps + [
+            "@com_github_gogo_protobuf//:gogo_proto_go",
+            "@com_github_golang_protobuf//ptypes/duration:go_default_library",
+            "@com_github_golang_protobuf//ptypes/struct:go_default_library",
+            "@com_github_golang_protobuf//ptypes/wrappers:go_default_library",
+            "@com_github_golang_protobuf//ptypes/any:go_default_library",
+            "@com_lyft_protoc_gen_validate//validate:go_default_library",
+            "@googleapis//:http_api_go_proto",
+        ]
     )
 
 # TODO(htuch): has_services is currently ignored but will in future support

--- a/test/build/BUILD
+++ b/test/build/BUILD
@@ -1,5 +1,4 @@
-load("//bazel:api_build_system.bzl", "api_cc_test")
-load("@io_bazel_rules_go//go:def.bzl", "go_test")
+load("//bazel:api_build_system.bzl", "api_cc_test", "api_go_test")
 
 licenses(["notice"])  # Apache 2
 
@@ -19,7 +18,7 @@ api_cc_test(
     ],
 )
 
-go_test(
+api_go_test(
     name = "go_build_test",
     size = "small",
     srcs = ["go_build_test.go"],


### PR DESCRIPTION
Created new definitions in api_build_system.bzl that wrap
go_proto_library, go_grpc_library, and go_test. Changed rules in api/BUILD and
test/build/BUILD to use these new definitions. In the future these
definitions could be expanded upon for auto generation in api_proto_library.

Signed-off-by: Kyle Myerson <kmyerson@google.com>