### PR TITLE
grpc_service: add stat_prefix field.

### DIFF
--- a/api/grpc_service.proto
+++ b/api/grpc_service.proto
@@ -78,4 +78,15 @@ message GrpcService {
   // A set of credentials that will be composed to form the `channel credentials
   // <https://grpc.io/docs/guides/auth.html#credential-types>`_.
   repeated Credentials credentials = 4;
+
+  // The human readable prefix to use when emitting statistics for the gRPC
+  // service.
+  //
+  // .. csv-table::
+  //    :header: Name, Type, Description
+  //    :widths: 1, 1, 2
+  //
+  //    streams_total, Counter, Total number of streams opened
+  //    streams_closed_<gRPC status code>, Counter, Total streams closed with <gRPC status code>
+  string stat_prefix = 5 [(validate.rules).string.min_bytes = 1];
 }

--- a/api/grpc_service.proto
+++ b/api/grpc_service.proto
@@ -39,6 +39,17 @@ message GrpcService {
       DataSource cert_chain = 3;
     }
     SslCredentials ssl_credentials = 2;
+
+    // The human readable prefix to use when emitting statistics for the gRPC
+    // service.
+    //
+    // .. csv-table::
+    //    :header: Name, Type, Description
+    //    :widths: 1, 1, 2
+    //
+    //    streams_total, Counter, Total number of streams opened
+    //    streams_closed_<gRPC status code>, Counter, Total streams closed with <gRPC status code>
+    string stat_prefix = 3 [(validate.rules).string.min_bytes = 1];
   }
 
   oneof target_specifier {
@@ -78,15 +89,4 @@ message GrpcService {
   // A set of credentials that will be composed to form the `channel credentials
   // <https://grpc.io/docs/guides/auth.html#credential-types>`_.
   repeated Credentials credentials = 4;
-
-  // The human readable prefix to use when emitting statistics for the gRPC
-  // service.
-  //
-  // .. csv-table::
-  //    :header: Name, Type, Description
-  //    :widths: 1, 1, 2
-  //
-  //    streams_total, Counter, Total number of streams opened
-  //    streams_closed_<gRPC status code>, Counter, Total streams closed with <gRPC status code>
-  string stat_prefix = 5 [(validate.rules).string.min_bytes = 1];
 }


### PR DESCRIPTION
We need to track statistics in a client neutral way, since the Google
gRPC client doesn't have upstream stats. This will allow us to track the
gRPC status returned by the remote (or inferred from events such as
client timeouts).

Signed-off-by: Harvey Tuch <htuch@google.com>