### PR TITLE
cds: remove cds metadata not-implemented tag

### DIFF
--- a/api/cds.proto
+++ b/api/cds.proto
@@ -407,12 +407,11 @@ message Cluster {
   // See :ref:`base.TransportSocket<envoy_api_msg_TransportSocket>` description.
   TransportSocket transport_socket = 24;
 
-  // [#not-implemented-hide:] The Metadata field can be used to provide
-  // additional information about the cluster. It can be used for stats,
-  // logging, and varying filter behavior. Fields should use reverse DNS
-  // notation to denote which entity within Envoy will need the information.
-  // For instance, if the metadata is intended for the Router filter, the filter
-  // name should be specified as *envoy.router*.
+  // The Metadata field can be used to provide additional information about the
+  // cluster. It can be used for stats, logging, and varying filter behavior.
+  // Fields should use reverse DNS notation to denote which entity within Envoy
+  // will need the information. For instance, if the metadata is intended for
+  // the Router filter, the filter name should be specified as *envoy.router*.
   Metadata metadata = 25;
 
   enum ClusterProtocolSelection {


### PR DESCRIPTION
This is the corresponding doc change for an Envoy update to make the CDS metadata field accessible in ClusterInfo.