### PR TITLE
docs: fix misnamed field in examples and g++ vs. c++

### DIFF
--- a/docs/root/configuration/overview/v2_overview.rst
+++ b/docs/root/configuration/overview/v2_overview.rst
@@ -145,7 +145,7 @@ on 127.0.0.3:5678 is provided below:
         eds_config:
           api_config_source:
             api_type: GRPC
-            cluster_name: [xds_cluster]
+            cluster_names: [xds_cluster]
     - name: xds_cluster
       connect_timeout: 0.25s
       type: STATIC
@@ -198,11 +198,11 @@ below:
     lds_config:
       api_config_source:
         api_type: GRPC
-        cluster_name: [xds_cluster]
+        cluster_names: [xds_cluster]
     cds_config:
       api_config_source:
         api_type: GRPC
-        cluster_name: [xds_cluster]
+        cluster_names: [xds_cluster]
 
   static_resources:
     clusters:
@@ -236,7 +236,7 @@ The management server could respond to LDS requests with:
             config_source:
               api_config_source:
                 api_type: GRPC
-                cluster_name: [xds_cluster]
+                cluster_names: [xds_cluster]
           http_filters:
           - name: envoy.router
 
@@ -270,7 +270,7 @@ The management server could respond to CDS requests with:
       eds_config:
         api_config_source:
           api_type: GRPC
-          cluster_name: [xds_cluster]
+          cluster_names: [xds_cluster]
 
 The management server could respond to EDS requests with:
 
@@ -313,7 +313,7 @@ for the service definition. This is used by Envoy as a client when
     cds_config:
       api_config_source:
         api_type: GRPC
-        cluster_name: [some_xds_cluster]
+        cluster_names: [some_xds_cluster]
 
 is set in the :ref:`dynamic_resources
 <envoy_api_field_Bootstrap.dynamic_resources>` of the :ref:`Bootstrap
@@ -330,7 +330,7 @@ for the service definition. This is used by Envoy as a client when
     eds_config:
       api_config_source:
         api_type: GRPC
-        cluster_name: [some_xds_cluster]
+        cluster_names: [some_xds_cluster]
 
 is set in the :ref:`eds_cluster_config
 <envoy_api_field_Cluster.eds_cluster_config>` field of the :ref:`Cluster
@@ -347,7 +347,7 @@ for the service definition. This is used by Envoy as a client when
     lds_config:
       api_config_source:
         api_type: GRPC
-        cluster_name: [some_xds_cluster]
+        cluster_names: [some_xds_cluster]
 
 is set in the :ref:`dynamic_resources
 <envoy_api_field_Bootstrap.dynamic_resources>` of the :ref:`Bootstrap
@@ -365,7 +365,7 @@ for the service definition. This is used by Envoy as a client when
     config_source:
       api_config_source:
         api_type: GRPC
-        cluster_name: [some_xds_cluster]
+        cluster_names: [some_xds_cluster]
 
 is set in the :ref:`rds
 <envoy_api_field_filter.network.HttpConnectionManager.rds>` field of the :ref:`HttpConnectionManager
@@ -385,7 +385,7 @@ for the service definition. This is used by Envoy as a client when
     cds_config:
       api_config_source:
         api_type: REST
-        cluster_name: [some_xds_cluster]
+        cluster_names: [some_xds_cluster]
 
 is set in the :ref:`dynamic_resources
 <envoy_api_field_Bootstrap.dynamic_resources>` of the :ref:`Bootstrap
@@ -402,7 +402,7 @@ for the service definition. This is used by Envoy as a client when
     eds_config:
       api_config_source:
         api_type: REST
-        cluster_name: [some_xds_cluster]
+        cluster_names: [some_xds_cluster]
 
 is set in the :ref:`eds_cluster_config
 <envoy_api_field_Cluster.eds_cluster_config>` field of the :ref:`Cluster
@@ -419,7 +419,7 @@ for the service definition. This is used by Envoy as a client when
     lds_config:
       api_config_source:
         api_type: REST
-        cluster_name: [some_xds_cluster]
+        cluster_names: [some_xds_cluster]
 
 is set in the :ref:`dynamic_resources
 <envoy_api_field_Bootstrap.dynamic_resources>` of the :ref:`Bootstrap
@@ -437,7 +437,7 @@ for the service definition. This is used by Envoy as a client when
     config_source:
       api_config_source:
         api_type: REST
-        cluster_name: [some_xds_cluster]
+        cluster_names: [some_xds_cluster]
 
 is set in the :ref:`rds
 <envoy_api_field_filter.network.HttpConnectionManager.rds>` field of the :ref:`HttpConnectionManager
@@ -485,7 +485,7 @@ for the service definition. This is used by Envoy as a client when
 
     ads_config:
       api_type: GRPC
-      cluster_name: [some_ads_cluster]
+      cluster_names: [some_ads_cluster]
 
 is set in the :ref:`dynamic_resources
 <envoy_api_field_Bootstrap.dynamic_resources>` of the :ref:`Bootstrap
@@ -499,7 +499,7 @@ be set to use the ADS channel. For example, a LDS config could be changed from
     lds_config:
       api_config_source:
         api_type: REST
-        cluster_name: [some_xds_cluster]
+        cluster_names: [some_xds_cluster]
 
 to
 

--- a/docs/root/intro/arch_overview/grpc.rst
+++ b/docs/root/intro/arch_overview/grpc.rst
@@ -65,4 +65,4 @@ independent of Envoy's cluster management.
 It is recommended to use the Envoy gRPC client in most cases, where the advanced
 features in the Google C++ gRPC client are not required. This provides
 configuration and monitoring simplicity. Where necessary features are missing
-in the Envoy gRPC client, the Google G++ gRPC client should be used instead.
+in the Envoy gRPC client, the Google C++ gRPC client should be used instead.


### PR DESCRIPTION
Fix `cluster_name` vs `cluster_names` typo in examples and G++ vs C++ in GRPC overview.

Signed-off-by: Stephan Zuercher <stephan@turbinelabs.io>