### PR TITLE
go: override root level package name

### DIFF
--- a/api/base.proto
+++ b/api/base.proto
@@ -1,7 +1,7 @@
 syntax = "proto3";
 
 package envoy.api.v2;
-option go_package="api";
+option go_package = "api";
 
 import "api/address.proto";
 

--- a/api/base.proto
+++ b/api/base.proto
@@ -1,6 +1,7 @@
 syntax = "proto3";
 
 package envoy.api.v2;
+option go_package="api";
 
 import "api/address.proto";
 


### PR DESCRIPTION
In golang, protoc needs all files in the same directory to belong to the same package. 
This PR forces all compiled protos in the root directory to belong to the `api` package.
 
Signed-off-by: Jose Nino <jnino@lyft.com>