### PR TITLE
admin: document /runtime endpoint

### DIFF
--- a/docs/root/operations/admin.rst
+++ b/docs/root/operations/admin.rst
@@ -168,7 +168,7 @@ The fields are:
 .. http:get:: /runtime
 
   Outputs all runtime values on demand in a human-readable format. See
-  :ref:`here <config_runtime_v1>` for more information on how these values are configured
+  :ref:`here <arch_overview_runtime>` for more information on how these values are configured
   and utilized.
 
   .. http:get:: /runtime?format=json

--- a/docs/root/operations/admin.rst
+++ b/docs/root/operations/admin.rst
@@ -167,8 +167,8 @@ The fields are:
 
 .. http:get:: /runtime
 
-  Outputs all runtime values on demand in a human-readable format. See 
-  :ref:`here <config_runtime_v1>` for more information on how these values are configured 
+  Outputs all runtime values on demand in a human-readable format. See
+  :ref:`here <config_runtime_v1>` for more information on how these values are configured
   and utilized.
 
   .. http:get:: /runtime?format=json

--- a/docs/root/operations/admin.rst
+++ b/docs/root/operations/admin.rst
@@ -164,3 +164,12 @@ The fields are:
   Outputs /stats in `Prometheus <https://prometheus.io/docs/instrumenting/exposition_formats/>`_
   v0.0.4 format. This can be used to integrate with a Prometheus server. Currently, only counters and
   gauges are outputed. Histograms will be outputed in a future update.
+
+.. http:get:: /runtime
+
+  Outputs all runtime values on demand. See :ref:`here <config_runtime_v1>` for more information on
+  how these values are configured and utilized.
+
+  .. http:get:: /runtime?format=json
+
+  Outputs /runtime in JSON format. This can be used for programmatic access of runtime values.

--- a/docs/root/operations/admin.rst
+++ b/docs/root/operations/admin.rst
@@ -167,8 +167,9 @@ The fields are:
 
 .. http:get:: /runtime
 
-  Outputs all runtime values on demand. See :ref:`here <config_runtime_v1>` for more information on
-  how these values are configured and utilized.
+  Outputs all runtime values on demand in a human-readable format. See 
+  :ref:`here <config_runtime_v1>` for more information on how these values are configured 
+  and utilized.
 
   .. http:get:: /runtime?format=json
 


### PR DESCRIPTION
Documents the `/runtime` admin endpoint added for read-only access to the current runtime values.

Related: https://github.com/envoyproxy/envoy/pull/2353