### PR TITLE
docs: add gateway-error as one of retry-on policies

### DIFF
--- a/docs/root/configuration/http_filters/router_filter.rst
+++ b/docs/root/configuration/http_filters/router_filter.rst
@@ -80,6 +80,10 @@ using a ',' delimited list. The supported policies are:
     :ref:`config_http_filters_router_x-envoy-upstream-rq-timeout-ms` is an outer time limit for a
     request, including any retries that take place.
 
+gateway-error
+  Envoy will attempt a retry if the upstream server responds with 502, 503 or 504 response code. This policy should have
+  the same behavior with 5xx, despite the smaller number of response codes to be checked.
+
 connect-failure
   Envoy will attempt a retry if a request is failed because of a connection failure to the upstream
   server (connect timeout, etc.). (Included in *5xx*)

--- a/docs/root/configuration/http_filters/router_filter.rst
+++ b/docs/root/configuration/http_filters/router_filter.rst
@@ -81,8 +81,8 @@ using a ',' delimited list. The supported policies are:
     request, including any retries that take place.
 
 gateway-error
-  Envoy will attempt a retry if the upstream server responds with 502, 503 or 504 response code. This policy should have
-  the same behavior with 5xx, despite the smaller number of response codes to be checked.
+  Envoy will attempt a retry if the upstream server responds with 502, 503, or 504 response code.
+  This policy is similar to the *5xx* policy but will only retry requests that result in a 502, 503, or 504.
 
 connect-failure
   Envoy will attempt a retry if a request is failed because of a connection failure to the upstream

--- a/docs/root/configuration/http_filters/router_filter.rst
+++ b/docs/root/configuration/http_filters/router_filter.rst
@@ -81,7 +81,6 @@ using a ',' delimited list. The supported policies are:
     request, including any retries that take place.
 
 gateway-error
-  Envoy will attempt a retry if the upstream server responds with 502, 503, or 504 response code.
   This policy is similar to the *5xx* policy but will only retry requests that result in a 502, 503, or 504.
 
 connect-failure


### PR DESCRIPTION
This patch adds doc for adding gateway-error as a retry-on policy, i.e. when the received response code is classified as a gateway error (502, 503 and 504). It is a subset of 5xx.

Ref: https://github.com/envoyproxy/envoy/issues/2300