### PR TITLE
Healthcheck filter: compute response based on upstream cluster health

### DIFF
--- a/STYLE.md
+++ b/STYLE.md
@@ -67,3 +67,5 @@ In addition, the following conventions should be followed:
   ```
 
   This is more efficient, extendable and self-describing.
+
+* To represent percentage values, use the Percent message type defined in [api/base.proto](api/base.proto).

--- a/api/base.proto
+++ b/api/base.proto
@@ -35,6 +35,11 @@ message Locality {
   string sub_zone = 3;
 }
 
+// Identifies a percentage, in the range [0.0, 100.0].
+message Percent {
+  double value = 1 [(validate.rules).double = {gte: 0, lte: 100}];
+}
+
 // Identifies a specific Envoy instance. The node identifier is presented to the
 // management server, which may use this identifier to distinguish per Envoy
 // configuration for serving.

--- a/api/filter/http/BUILD
+++ b/api/filter/http/BUILD
@@ -37,6 +37,9 @@ api_proto_library(
 api_proto_library(
     name = "health_check",
     srcs = ["health_check.proto"],
+    deps = [
+        "//api:base",
+    ],
 )
 
 api_proto_library(

--- a/api/filter/http/health_check.proto
+++ b/api/filter/http/health_check.proto
@@ -21,4 +21,10 @@ message HealthCheck {
   // If operating in pass through mode, the amount of time in milliseconds
   // that the filter should cache the upstream response.
   google.protobuf.Duration cache_time = 3;
+
+  // [#not-implemented-hide:]
+  // If operating in non pass through mode, specifies a set of upstream cluster
+  // names and the minimum percentage of servers in each of those clusters that
+  //  must be healthy in order for the filter to return a 200.
+  map<string, uint32> cluster_min_percentages = 4;
 }

--- a/api/filter/http/health_check.proto
+++ b/api/filter/http/health_check.proto
@@ -5,6 +5,7 @@ package envoy.api.v2.filter.http;
 import "google/protobuf/duration.proto";
 import "google/protobuf/wrappers.proto";
 
+import "api/base.proto";
 import "validate/validate.proto";
 
 // [#protodoc-title: Health check]
@@ -26,5 +27,5 @@ message HealthCheck {
   // If operating in non-pass-through mode, specifies a set of upstream cluster
   // names and the minimum percentage of servers in each of those clusters that
   //  must be healthy in order for the filter to return a 200.
-  map<string, uint32> cluster_min_healthy_percentages = 4;
+  map<string, Percent> cluster_min_healthy_percentages = 4;
 }

--- a/api/filter/http/health_check.proto
+++ b/api/filter/http/health_check.proto
@@ -23,8 +23,8 @@ message HealthCheck {
   google.protobuf.Duration cache_time = 3;
 
   // [#not-implemented-hide:]
-  // If operating in non pass through mode, specifies a set of upstream cluster
+  // If operating in non-pass-through mode, specifies a set of upstream cluster
   // names and the minimum percentage of servers in each of those clusters that
   //  must be healthy in order for the filter to return a 200.
-  map<string, uint32> cluster_min_percentages = 4;
+  map<string, uint32> cluster_min_healthy_percentages = 4;
 }


### PR DESCRIPTION
*Description*:
Extend the "non pass through" mode of the HTTP health check filter to allow an
optional map from cluster names to percentages. If specified, each of the named
clusters must have at least the specified percentage of its servers healthy for
the filter to return a 200. (The proxy also must be in a non-draining state, or
else the filter will return a 503 like it did previously.)

Associated envoyproxy/envoy issue: https://github.com/envoyproxy/envoy/issues/2362

Signed-off-by: Brian Pane <bpane@pinterest.com>