### PR TITLE
Add *_headers_to_add to `ClusterWeight`

### DIFF
--- a/envoy/api/v2/route/route.proto
+++ b/envoy/api/v2/route/route.proto
@@ -209,6 +209,7 @@ message WeightedCluster {
     // considered. The filter name should be specified as *envoy.lb*.
     Metadata metadata_match = 3;
 
+    // [#not-implemented-hide:]
     // Specifies a list of headers to be added to requests when this cluster is selected
     // through the enclosing :ref:`envoy_api_msg_route.RouteAction`.
     // Headers specified at this level are applied before headers from the enclosing
@@ -219,6 +220,7 @@ message WeightedCluster {
     // <config_http_conn_man_headers_custom_request_headers>`.
     repeated HeaderValueOption request_headers_to_add = 4;
 
+    // [#not-implemented-hide:]
     // Specifies a list of headers to be added to responses when this cluster is selected
     // through the enclosing :ref:`envoy_api_msg_route.RouteAction`.
     // Headers specified at this level are applied before headers from the enclosing

--- a/envoy/api/v2/route/route.proto
+++ b/envoy/api/v2/route/route.proto
@@ -208,6 +208,26 @@ message WeightedCluster {
     // cluster with metadata matching that set in metadata_match will be
     // considered. The filter name should be specified as *envoy.lb*.
     Metadata metadata_match = 3;
+
+    // Specifies a list of headers to be added to requests when this cluster is selected
+    // through the enclosing :ref:`envoy_api_msg_route.RouteAction`.
+    // Headers specified at this level are applied before headers from the enclosing
+    // :ref:`envoy_api_msg_route.RouteAction`,
+    // :ref:`envoy_api_msg_route.VirtualHost`, and
+    // :ref:`envoy_api_msg_route.RouteConfiguration`. For more information, including details on
+    // header value syntax, see the documentation on :ref:`custom request headers
+    // <config_http_conn_man_headers_custom_request_headers>`.
+    repeated HeaderValueOption request_headers_to_add = 4;
+
+    // Specifies a list of headers to be added to responses when this cluster is selected
+    // through the enclosing :ref:`envoy_api_msg_route.RouteAction`.
+    // Headers specified at this level are applied before headers from the enclosing
+    // :ref:`envoy_api_msg_route.RouteAction`,
+    // :ref:`envoy_api_msg_route.VirtualHost`, and
+    // :ref:`envoy_api_msg_route.RouteConfiguration`. For more information, including details on
+    // header value syntax, see the documentation on :ref:`custom request headers
+    // <config_http_conn_man_headers_custom_request_headers>`.
+    repeated HeaderValueOption response_headers_to_add = 5;
   }
 
   // Specifies one or more upstream clusters associated with the route.

--- a/envoy/api/v2/route/route.proto
+++ b/envoy/api/v2/route/route.proto
@@ -230,6 +230,11 @@ message WeightedCluster {
     // header value syntax, see the documentation on :ref:`custom request headers
     // <config_http_conn_man_headers_custom_request_headers>`.
     repeated HeaderValueOption response_headers_to_add = 5;
+
+    // [#not-implemented-hide:]
+    // Specifies a list of headers to be removed from responses when this cluster is selected
+    // through the enclosing :ref:`envoy_api_msg_route.RouteAction`.
+    repeated string response_headers_to_remove = 6;
   }
 
   // Specifies one or more upstream clusters associated with the route.


### PR DESCRIPTION
Add request_headers_to_add and response_headers_to_add to ClusterWeight.

The directives are processed when the cluster in selected through the enclosing RouteAction.

reference: https://github.com/envoyproxy/envoy/issues/2455

Signed-off-by: Mandar U Jog <mjog@google.com>