### PR TITLE
Expose trace sampling controls

### DIFF
--- a/envoy/api/v2/filter/network/http_connection_manager.proto
+++ b/envoy/api/v2/filter/network/http_connection_manager.proto
@@ -83,9 +83,10 @@ message HttpConnectionManager {
     repeated string request_headers_for_tags = 2;
 
     // Target percentage of requests managed by this HTTP connection manager that will be force
-    // traced if the *x-client-trace-id* header is set. This field is a direct analog for the
-    // runtime variable 'tracing.client_sampling' in the
-    // :ref:`HTTP Connection Manager <config_http_conn_man_runtime>`.
+    // traced if the :ref:`x-client-trace-id <config_http_conn_man_headers_x-client-trace-id>`
+    // header is set. This field is a direct analog for the runtime variable
+    // 'tracing.client_sampling' in the :ref:`HTTP Connection Manager
+    // <config_http_conn_man_runtime>`.
     // Default: 100%
     Percent client_sampling = 3;
 

--- a/envoy/api/v2/filter/network/http_connection_manager.proto
+++ b/envoy/api/v2/filter/network/http_connection_manager.proto
@@ -82,16 +82,29 @@ message HttpConnectionManager {
     // created if the specified header name is present in the request's headers.
     repeated string request_headers_for_tags = 2;
 
-    // Target percentage of requests managed by this HTTP connection manager that will be traced
-    // after all other checks have been applied (force tracing, sampling, etc.). Defaults to 100%.
-    // This variable is a direct analog for the variable named 'global_enabled' in the :ref:`HTTP
-    // Connection Manager <config_http_conn_man_runtime>`.
-    Percent sampling = 3;
+    // Target percentage of requests managed by this HTTP connection manager that will be force
+    // traced if the *x-client-trace-id* header is set. This field is a direct analog for the
+    // runtime variable 'tracing.client_sampling' in the
+    // :ref:`HTTP Connection Manager <config_http_conn_man_runtime>`.
+    // Default: 100%
+    Percent client_sampling = 3;
 
     // Target percentage of requests managed by this HTTP connection manager that will be randomly
-    // traced. Defaults to 100%. This variable is a direct analog for the variable of the same name
-    // in the :ref:`HTTP Connection Manager <config_http_conn_man_runtime>`.
+    // selected for trace generation, if not requested by the client or not forced. This field is
+    // a direct analog for the runtime variable 'tracing.random_sampling' in the
+    // :ref:`HTTP Connection Manager <config_http_conn_man_runtime>`.
+    // Default: 100%
     Percent random_sampling = 4;
+
+    // Target percentage of requests managed by this HTTP connection manager that will be traced
+    // after all other sampling checks have been applied (client-directed, force tracing, random
+    // sampling). This field functions as an upper limit on the total configured sampling rate. For
+    // instance, setting client_sampling to 100% but overall_sampling to 1% will result in only 1%
+    // of client requests with the appropriate headers to be force traced. This field is a direct
+    // analog for the runtime variable 'tracing.global_enabled' in the
+    // :ref:`HTTP Connection Manager <config_http_conn_man_runtime>`.
+    // Default: 100%
+    Percent overall_sampling = 5;
   }
 
   // Presence of the object defines whether the connection manager

--- a/envoy/api/v2/filter/network/http_connection_manager.proto
+++ b/envoy/api/v2/filter/network/http_connection_manager.proto
@@ -3,6 +3,7 @@ syntax = "proto3";
 package envoy.api.v2.filter.network;
 option go_package = "network";
 
+import "envoy/api/v2/base.proto";
 import "envoy/api/v2/config_source.proto";
 import "envoy/api/v2/protocol.proto";
 import "envoy/api/v2/filter/accesslog/accesslog.proto";
@@ -80,6 +81,17 @@ message HttpConnectionManager {
     // populate the tag name, and the header value is used to populate the tag value. The tag is
     // created if the specified header name is present in the request's headers.
     repeated string request_headers_for_tags = 2;
+
+    // Target percentage of requests managed by this HTTP connection manager that will be traced
+    // after all other checks have been applied (force tracing, sampling, etc.). Defaults to 100%.
+    // This variable is a direct analog for the variable named 'global_enabled' in the :ref:`HTTP
+    // Connection Manager <config_http_conn_man_runtime>`.
+    Percent sampling = 3;
+
+    // Target percentage of requests managed by this HTTP connection manager that will be randomly
+    // traced. Defaults to 100%. This variable is a direct analog for the variable of the same name
+    // in the :ref:`HTTP Connection Manager <config_http_conn_man_runtime>`.
+    Percent random_sampling = 4;
   }
 
   // Presence of the object defines whether the connection manager


### PR DESCRIPTION
This PR adds trace sampling controls to the public API. It is a continuation of work from PR #375.

The controls added:
- `Tracing.sampling` (equivalent to [tracing.global_enabled](https://www.envoyproxy.io/docs/envoy/latest/configuration/http_conn_man/runtime.html?highlight=global_enabled))
- `Tracing.random_sampling` (equivalent to [tracing.random_sampling](https://www.envoyproxy.io/docs/envoy/latest/configuration/http_conn_man/runtime.html?highlight=random_sampling))


Signed-off-by: Douglas Reid <douglas-reid@users.noreply.github.com>