### PR TITLE
Document DOWNSTREAM_LOCAL_ADDRESS header variable

### DIFF
--- a/docs/root/configuration/access_log.rst
+++ b/docs/root/configuration/access_log.rst
@@ -130,8 +130,14 @@ The following command operators are supported:
     <config_http_conn_man_headers_x-forwarded-for>`.
 
 %DOWNSTREAM_LOCAL_ADDRESS%
-  Remote address of the downstream connection. If the address is an IP address it includes both
+  Local address of the downstream connection. If the address is an IP address it includes both
   address and port.
+  If the original connection was redirected by iptables REDIRECT, this represents
+  the original destination address restored by the
+  :ref:`Original Destination Filter <config_listener_filters_original_dst>` using SO_ORIGINAL_DST socket option.
+
+%DOWNSTREAM_LOCAL_ADDRESS_WITHOUT_PORT%
+    Same as **%DOWNSTREAM_LOCAL_ADDRESS%** excluding port if the address is an IP address.
 
 %REQ(X?Y):Z%
   HTTP

--- a/docs/root/configuration/http_conn_man/headers.rst
+++ b/docs/root/configuration/http_conn_man/headers.rst
@@ -318,6 +318,14 @@ Supported variable names are:
       :ref:`proxy proto <envoy_api_field_listener.FilterChain.use_proxy_proto>` or :ref:`x-forwarded-for
       <config_http_conn_man_headers_x-forwarded-for>`.
 
+%DOWNSTREAM_LOCAL_ADDRESS_WITHOUT_PORT%
+    Local address of the downstream connection. If the address is an IP address the output does
+    *not* include port. If the original connection is redirected by iptables REDIRECT, this represents
+    the original destination address restored using SO_ORIGINAL_DST socket option.
+
+%ORIGINAL_DST%
+    An alias for %DOWNSTREAM_LOCAL_ADDRESS_WITHOUT_PORT%.
+
 %PROTOCOL%
     The original protocol which is already added by Envoy as a
     :ref:`x-forwarded-proto <config_http_conn_man_headers_x-forwarded-proto>` request header.

--- a/docs/root/configuration/http_conn_man/headers.rst
+++ b/docs/root/configuration/http_conn_man/headers.rst
@@ -320,11 +320,9 @@ Supported variable names are:
 
 %DOWNSTREAM_LOCAL_ADDRESS_WITHOUT_PORT%
     Local address of the downstream connection. If the address is an IP address the output does
-    *not* include port. If the original connection is redirected by iptables REDIRECT, this represents
-    the original destination address restored using SO_ORIGINAL_DST socket option.
-
-%ORIGINAL_DST%
-    An alias for %DOWNSTREAM_LOCAL_ADDRESS_WITHOUT_PORT%.
+    *not* include port. If the original connection was redirected by iptables REDIRECT, this represents
+    the original destination address restored by the
+    :ref:`Original Destination Filter <config_listener_filters_original_dst>` using SO_ORIGINAL_DST socket option.
 
 %PROTOCOL%
     The original protocol which is already added by Envoy as a

--- a/docs/root/configuration/http_conn_man/headers.rst
+++ b/docs/root/configuration/http_conn_man/headers.rst
@@ -318,11 +318,15 @@ Supported variable names are:
       :ref:`proxy proto <envoy_api_field_listener.FilterChain.use_proxy_proto>` or :ref:`x-forwarded-for
       <config_http_conn_man_headers_x-forwarded-for>`.
 
-%DOWNSTREAM_LOCAL_ADDRESS_WITHOUT_PORT%
-    Local address of the downstream connection. If the address is an IP address the output does
-    *not* include port. If the original connection was redirected by iptables REDIRECT, this represents
+%DOWNSTREAM_LOCAL_ADDRESS%
+    Local address of the downstream connection. If the address is an IP address it includes both
+    address and port.
+    If the original connection was redirected by iptables REDIRECT, this represents
     the original destination address restored by the
     :ref:`Original Destination Filter <config_listener_filters_original_dst>` using SO_ORIGINAL_DST socket option.
+
+%DOWNSTREAM_LOCAL_ADDRESS_WITHOUT_PORT%
+    Same as **%DOWNSTREAM_LOCAL_ADDRESS%** excluding port if the address is an IP address.
 
 %PROTOCOL%
     The original protocol which is already added by Envoy as a


### PR DESCRIPTION
Document 
* DOWNSTREAM_LOCAL_ADDRESS
* DOWNSTREAM_LOCAL_ADDRESS_WITHOUT_PORT 
as header and access log variables.

Related to https://github.com/envoyproxy/envoy/pull/2487

