### PR TITLE
docs: fix typo lua headers replace API

### DIFF
--- a/docs/root/configuration/http_filters/lua_filter.rst
+++ b/docs/root/configuration/http_filters/lua_filter.rst
@@ -335,7 +335,7 @@ replace()
 
 .. code-block:: lua
 
-  headers:add(key, value)
+  headers:replace(key, value)
 
 Replaces a header. *key* is a string that supplies the header key. *value* is a string that supplies
 the header value. If the header does not exist, it is added as per the *add()* function.


### PR DESCRIPTION
This patch fixes a small typo in the lua `headers:replace` API doc.

Signed-off-by: Dhi Aurrahman <dio@hooq.tv>