### PR TITLE
address.proto: added doc for abstract sockets

### DIFF
--- a/envoy/api/v2/core/address.proto
+++ b/envoy/api/v2/core/address.proto
@@ -12,8 +12,10 @@ option (gogoproto.equal_all) = true;
 // [#protodoc-title: Network addresses]
 
 message Pipe {
-  // Unix Domain Socket path. On linux, paths starting with '@' will use the
-  // abstract namespace, '@' being interpreted as a null byte.
+  // Unix Domain Socket path. On Linux, paths starting with '@' will use the
+  // abstract namespace. The starting '@' is replaced by a null byte by Envoy.
+  // Paths starting with '@' will result in an error in environments other than
+  // Linux.
   string path = 1 [(validate.rules).string.min_bytes = 1];
 }
 

--- a/envoy/api/v2/core/address.proto
+++ b/envoy/api/v2/core/address.proto
@@ -12,7 +12,8 @@ option (gogoproto.equal_all) = true;
 // [#protodoc-title: Network addresses]
 
 message Pipe {
-  // Unix Domain Socket path.
+  // Unix Domain Socket path. On linux, paths starting with '@' will use the
+  // abstract namespace, '@' being interpreted as a null byte.
   string path = 1 [(validate.rules).string.min_bytes = 1];
 }
 


### PR DESCRIPTION
This is a follow up to https://github.com/envoyproxy/envoy/pull/2512