### PR TITLE
Fix bazel fetch command by providing //external:python_headers

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -18,6 +18,13 @@ http_archive(
     urls = ["https://github.com/google/protobuf/archive/v3.5.0.tar.gz"],
 )
 
+# Needed for ``bazel fetch`` to work with @com_google_protobuf
+# https://github.com/google/protobuf/blob/v3.5.0/util/python/BUILD#L6-L9
+bind(
+    name = "python_headers",
+    actual = "@com_google_protobuf//util/python:python_headers",
+)
+
 bind(
     name = "six",
     actual = "@six_archive//:six",


### PR DESCRIPTION
For whatever reason, `bazel fetch` needs this resource defined while `bazel build` does not 😕. I would like to be able to run `bazel fetch` to fetch external dependencies without having to build the C++ or Go protobuf binaries.

cc: @htuch 