### PR TITLE
Adds ability to configure ZoneAwareLoadBalancing settings as config options 

### DIFF
--- a/envoy/api/v2/cds.proto
+++ b/envoy/api/v2/cds.proto
@@ -356,10 +356,15 @@ message Cluster {
     // .. note::
     //   The specified percent will be truncated to the nearest 1%.
     core.Percent healthy_panic_threshold = 1;
-    //Configuration for ZoneAwareLoadBalancer
-    // [#not-implemented-hide:] If specified envoy can use this config option to decide on applying ZoneAwareLoadBalancing
+    // [#not-implemented-hide:] Configures percentage of requests that will be routed to same zone
+    // If not specified, the default is 100%.
+    // :ref:`runtime values <config_cluster_manager_cluster_runtime_zone_routing>`.
+    // :ref:`Zone aware routing support <arch_overview_load_balancing_zone_aware_routing>`.
     core.Percent zone_aware_routing_enabled = 2;
-    // [#not-implemented-hide:] If specified envoy can use this config instead of upstream.zone_aware_routing.min_cluster_size as a runtime option
+    // [#not-implemented-hide:] Configures minimum upstream cluster size for zone aware routing
+    // If not specified, the default is 6.
+    // :ref:`runtime values <config_cluster_manager_cluster_runtime_zone_routing>`.
+    // :ref:`Zone aware routing support <arch_overview_load_balancing_zone_aware_routing>`.
     google.protobuf.UInt64Value zone_aware_routing_min_cluster_size = 3;
   }
 

--- a/envoy/api/v2/cds.proto
+++ b/envoy/api/v2/cds.proto
@@ -363,7 +363,9 @@ message Cluster {
     // :ref:`Zone aware routing support <arch_overview_load_balancing_zone_aware_routing>`.
     core.Percent zone_aware_routing_enabled = 2;
     // [#not-implemented-hide:]
-    // Configures minimum upstream cluster size for zone aware routing
+    // Configures minimum upstream cluster size required for zone aware routing
+    // If upstream cluster size is less than specified ,zone aware routing is not performed
+    // even configured.
     // If not specified, the default is 6.
     // :ref:`runtime values <config_cluster_manager_cluster_runtime_zone_routing>`.
     // :ref:`Zone aware routing support <arch_overview_load_balancing_zone_aware_routing>`.

--- a/envoy/api/v2/cds.proto
+++ b/envoy/api/v2/cds.proto
@@ -356,19 +356,21 @@ message Cluster {
     // .. note::
     //   The specified percent will be truncated to the nearest 1%.
     core.Percent healthy_panic_threshold = 1;
-    // [#not-implemented-hide:]
-    // Configures percentage of requests that will be routed to same zone
-    // If not specified, the default is 100%.
-    // :ref:`runtime values <config_cluster_manager_cluster_runtime_zone_routing>`.
-    // :ref:`Zone aware routing support <arch_overview_load_balancing_zone_aware_routing>`.
-    core.Percent zone_aware_routing_enabled = 2;
-    // [#not-implemented-hide:]
-    // Configures minimum upstream cluster size required for zone aware routing
-    // If upstream cluster size is less than specified, zone aware routing is not performed
-    // even if configured . If not specified, the default is 6.
-    // :ref:`runtime values <config_cluster_manager_cluster_runtime_zone_routing>`.
-    // :ref:`Zone aware routing support <arch_overview_load_balancing_zone_aware_routing>`.
-    google.protobuf.UInt64Value zone_aware_routing_min_cluster_size = 3;
+    message ZoneAwareLbConfig {
+      // [#not-implemented-hide:]
+      // Configures percentage of requests that will be considered for zone aware routing
+      // if zone aware routing is configured. If not specified, the default is 100%.
+      // * :ref:`runtime values <config_cluster_manager_cluster_runtime_zone_routing>`.
+      // * :ref:`Zone aware routing support <arch_overview_load_balancing_zone_aware_routing>`.
+      core.Percent routing_enabled = 1;
+      // [#not-implemented-hide:]
+      // Configures minimum upstream cluster size required for zone aware routing
+      // If upstream cluster size is less than specified, zone aware routing is not performed
+      // even if configured. If not specified, the default is 6.
+      // * :ref:`runtime values <config_cluster_manager_cluster_runtime_zone_routing>`.
+      // * :ref:`Zone aware routing support <arch_overview_load_balancing_zone_aware_routing>`.
+      google.protobuf.UInt64Value min_cluster_size = 2;
+    }
   }
 
   // Common configuration for all load balancer implementations.

--- a/envoy/api/v2/cds.proto
+++ b/envoy/api/v2/cds.proto
@@ -356,6 +356,9 @@ message Cluster {
     // .. note::
     //   The specified percent will be truncated to the nearest 1%.
     core.Percent healthy_panic_threshold = 1;
+    //Configuration for ZoneAwareLoadBalancer
+    core.Percent zone_aware_routing_enabled = 100;
+    google.protobuf.UInt64Value zone_aware_routing_min_cluster_size = 6;
   }
 
   // Common configuration for all load balancer implementations.

--- a/envoy/api/v2/cds.proto
+++ b/envoy/api/v2/cds.proto
@@ -364,8 +364,8 @@ message Cluster {
     core.Percent zone_aware_routing_enabled = 2;
     // [#not-implemented-hide:]
     // Configures minimum upstream cluster size required for zone aware routing
-    // If upstream cluster size is less than specified ,zone aware routing is not performed
-    // even configured . If not specified, the default is 6.
+    // If upstream cluster size is less than specified, zone aware routing is not performed
+    // even if configured . If not specified, the default is 6.
     // :ref:`runtime values <config_cluster_manager_cluster_runtime_zone_routing>`.
     // :ref:`Zone aware routing support <arch_overview_load_balancing_zone_aware_routing>`.
     google.protobuf.UInt64Value zone_aware_routing_min_cluster_size = 3;

--- a/envoy/api/v2/cds.proto
+++ b/envoy/api/v2/cds.proto
@@ -365,8 +365,7 @@ message Cluster {
     // [#not-implemented-hide:]
     // Configures minimum upstream cluster size required for zone aware routing
     // If upstream cluster size is less than specified ,zone aware routing is not performed
-    // even configured.
-    // If not specified, the default is 6.
+    // even configured . If not specified, the default is 6.
     // :ref:`runtime values <config_cluster_manager_cluster_runtime_zone_routing>`.
     // :ref:`Zone aware routing support <arch_overview_load_balancing_zone_aware_routing>`.
     google.protobuf.UInt64Value zone_aware_routing_min_cluster_size = 3;

--- a/envoy/api/v2/cds.proto
+++ b/envoy/api/v2/cds.proto
@@ -356,12 +356,14 @@ message Cluster {
     // .. note::
     //   The specified percent will be truncated to the nearest 1%.
     core.Percent healthy_panic_threshold = 1;
-    // [#not-implemented-hide:] Configures percentage of requests that will be routed to same zone
+    // [#not-implemented-hide:]
+    // Configures percentage of requests that will be routed to same zone
     // If not specified, the default is 100%.
     // :ref:`runtime values <config_cluster_manager_cluster_runtime_zone_routing>`.
     // :ref:`Zone aware routing support <arch_overview_load_balancing_zone_aware_routing>`.
     core.Percent zone_aware_routing_enabled = 2;
-    // [#not-implemented-hide:] Configures minimum upstream cluster size for zone aware routing
+    // [#not-implemented-hide:]
+    // Configures minimum upstream cluster size for zone aware routing
     // If not specified, the default is 6.
     // :ref:`runtime values <config_cluster_manager_cluster_runtime_zone_routing>`.
     // :ref:`Zone aware routing support <arch_overview_load_balancing_zone_aware_routing>`.

--- a/envoy/api/v2/cds.proto
+++ b/envoy/api/v2/cds.proto
@@ -366,7 +366,7 @@ message Cluster {
       // [#not-implemented-hide:]
       // Configures minimum upstream cluster size required for zone aware routing
       // If upstream cluster size is less than specified, zone aware routing is not performed
-      // even if configured. If not specified, the default is 6.
+      // even if zone aware routing is configured. If not specified, the default is 6.
       // * :ref:`runtime values <config_cluster_manager_cluster_runtime_zone_routing>`.
       // * :ref:`Zone aware routing support <arch_overview_load_balancing_zone_aware_routing>`.
       google.protobuf.UInt64Value min_cluster_size = 2;

--- a/envoy/api/v2/cds.proto
+++ b/envoy/api/v2/cds.proto
@@ -357,8 +357,8 @@ message Cluster {
     //   The specified percent will be truncated to the nearest 1%.
     core.Percent healthy_panic_threshold = 1;
     //Configuration for ZoneAwareLoadBalancer
-    core.Percent zone_aware_routing_enabled = 100;
-    google.protobuf.UInt64Value zone_aware_routing_min_cluster_size = 6;
+    core.Percent zone_aware_routing_enabled = 2;
+    google.protobuf.UInt64Value zone_aware_routing_min_cluster_size = 3;
   }
 
   // Common configuration for all load balancer implementations.

--- a/envoy/api/v2/cds.proto
+++ b/envoy/api/v2/cds.proto
@@ -357,7 +357,9 @@ message Cluster {
     //   The specified percent will be truncated to the nearest 1%.
     core.Percent healthy_panic_threshold = 1;
     //Configuration for ZoneAwareLoadBalancer
+    // [#not-implemented-hide:] If specified envoy can use this config option to decide on applying ZoneAwareLoadBalancing
     core.Percent zone_aware_routing_enabled = 2;
+    // [#not-implemented-hide:] If specified envoy can use this config instead of upstream.zone_aware_routing.min_cluster_size as a runtime option
     google.protobuf.UInt64Value zone_aware_routing_min_cluster_size = 3;
   }
 


### PR DESCRIPTION
This adds ability to configure settings for zone aware load balancing settings as config options.
solves https://github.com/envoyproxy/envoy/issues/1344 


Changes : Added min_cluster_size and enabled_percentage to commonLbConfig which enables them to used directly in load_balancer_impl.cc


Signed-off-by   : sri kailash  <sri.gandebathula@booking.com>

