### PR TITLE
grpc: add opaque config for GoogleGrpc.

### DIFF
--- a/envoy/api/v2/core/grpc_service.proto
+++ b/envoy/api/v2/core/grpc_service.proto
@@ -5,6 +5,7 @@ package envoy.api.v2.core;
 import "envoy/api/v2/core/base.proto";
 
 import "google/protobuf/duration.proto";
+import "google/protobuf/struct.proto";
 
 import "validate/validate.proto";
 import "gogoproto/gogo.proto";
@@ -53,6 +54,10 @@ message GrpcService {
     //    streams_total, Counter, Total number of streams opened
     //    streams_closed_<gRPC status code>, Counter, Total streams closed with <gRPC status code>
     string stat_prefix = 3 [(validate.rules).string.min_bytes = 1];
+
+    // Additional configuration for site-specific customizations of the Google
+    // gRPC library.
+    google.protobuf.Struct config = 4;
   }
 
   oneof target_specifier {


### PR DESCRIPTION
Google has some internal customizations that require configuration to be
provided. Added a generic site local customization field.

Signed-off-by: Harvey Tuch <htuch@google.com>