### PR TITLE
docs: Add description for --disable-hot-restart cli flag

### DIFF
--- a/docs/root/operations/cli.rst
+++ b/docs/root/operations/cli.rst
@@ -175,3 +175,8 @@ following are the command line options that Envoy supports.
   *(optional)* The maximum number of stats that can be shared between hot-restarts. This setting
   affects the output of :option:`--hot-restart-version`; the same value must be used to hot
   restart. Defaults to 16384.
+
+.. option:: --disable-hot-restart
+
+  *(optional)* This flag disables Envoy hot restart for builds that have it enabled. By default, hot
+  restart is enabled.


### PR DESCRIPTION
This is the update to the documentation that's required once the `--disable-hot-restart` cli flag PR is merged. See https://github.com/envoyproxy/envoy/pull/2576.