### PR TITLE
External authorization review comments

### DIFF
--- a/envoy/config/filter/http/ext_authz/v2/ext_authz.proto
+++ b/envoy/config/filter/http/ext_authz/v2/ext_authz.proto
@@ -14,13 +14,13 @@ import "validate/validate.proto";
 message ExtAuthz {
 
   // The external authorization gRPC service configuration.
+  // Note: Only works with :ref:`Envoy's in-built gRPC client <envoy_api_msg_core.GrpcService.EnvoyGrpc>`
   envoy.api.v2.core.GrpcService grpc_service = 1;
 
   // The filter's behaviour in case the external authorization service does
   // not respond back. If set to true then in case of failure to get a
-  // response back from the authorization service allow the traffic.
+  // response back from the authorization service or getting a response that is NOT denied then
+  // traffic will be permitted.
   // Defaults to false.
-  // If set to true and the response from the authorization service is NOT
-  // Denied then the traffic will be permitted.
   bool failure_mode_allow = 2;
 }

--- a/envoy/config/filter/http/ext_authz/v2/ext_authz.proto
+++ b/envoy/config/filter/http/ext_authz/v2/ext_authz.proto
@@ -9,7 +9,8 @@ import "validate/validate.proto";
 
 // [#not-implemented-hide:]
 // External Authorization filter calls out to an external service over the
-// gRPC Authorization API defined by :ref:`external_auth <envoy_api_msg_auth.CheckRequest>`.
+// gRPC Authorization API defined by
+// :ref:`external_auth <envoy_api_msg_auth.CheckRequest>`.
 // A failed check will cause this filter to return 403 Forbidden.
 message ExtAuthz {
 
@@ -18,8 +19,8 @@ message ExtAuthz {
 
   // The filter's behaviour in case the external authorization service does
   // not respond back. If set to true then in case of failure to get a
-  // response back from the authorization service or getting a response that is NOT denied then
-  // traffic will be permitted.
+  // response back from the authorization service or getting a response that
+  // is NOT denied then traffic will be permitted.
   // Defaults to false.
   bool failure_mode_allow = 2;
 }

--- a/envoy/config/filter/http/ext_authz/v2/ext_authz.proto
+++ b/envoy/config/filter/http/ext_authz/v2/ext_authz.proto
@@ -14,7 +14,6 @@ import "validate/validate.proto";
 message ExtAuthz {
 
   // The external authorization gRPC service configuration.
-  // Note: Only works with :ref:`Envoy's in-built gRPC client <envoy_api_msg_core.GrpcService.EnvoyGrpc>`
   envoy.api.v2.core.GrpcService grpc_service = 1;
 
   // The filter's behaviour in case the external authorization service does

--- a/envoy/config/filter/network/ext_authz/v2/ext_authz.proto
+++ b/envoy/config/filter/network/ext_authz/v2/ext_authz.proto
@@ -9,7 +9,8 @@ import "validate/validate.proto";
 
 // [#not-implemented-hide:]
 // External Authorization filter calls out to an external service over the
-// gRPC Authorization API defined by :ref:`external_auth <envoy_api_msg_auth.CheckRequest>`.
+// gRPC Authorization API defined by
+// :ref:`external_auth <envoy_api_msg_auth.CheckRequest>`.
 // A failed check will cause this filter to close the TCP connection.
 message ExtAuthz {
   // The prefix to use when emitting statistics.
@@ -20,8 +21,8 @@ message ExtAuthz {
 
   // The filter's behaviour in case the external authorization service does
   // not respond back. If set to true then in case of failure to get a
-  // response back from the authorization service or getting a response that is NOT denied then
-  // traffic will be permitted.
+  // response back from the authorization service or getting a response that
+  // is NOT denied then traffic will be permitted.
   // Defaults to false.
   bool failure_mode_allow = 3;
 }

--- a/envoy/config/filter/network/ext_authz/v2/ext_authz.proto
+++ b/envoy/config/filter/network/ext_authz/v2/ext_authz.proto
@@ -16,13 +16,13 @@ message ExtAuthz {
   string stat_prefix = 1 [(validate.rules).string.min_bytes = 1];
 
   // The external authorization gRPC service configuration.
+  // Note: Only works with :ref:`Envoy's in-built gRPC client <envoy_api_msg_core.GrpcService.EnvoyGrpc>`
   envoy.api.v2.core.GrpcService grpc_service = 2;
 
   // The filter's behaviour in case the external authorization service does
   // not respond back. If set to true then in case of failure to get a
-  // response back from the authorization service allow the traffic.
+  // response back from the authorization service or getting a response that is NOT denied then
+  // traffic will be permitted.
   // Defaults to false.
-  // If set to true and the response from the authorization service is NOT
-  // Denied then the traffic will be permitted.
   bool failure_mode_allow = 3;
 }

--- a/envoy/config/filter/network/ext_authz/v2/ext_authz.proto
+++ b/envoy/config/filter/network/ext_authz/v2/ext_authz.proto
@@ -16,7 +16,6 @@ message ExtAuthz {
   string stat_prefix = 1 [(validate.rules).string.min_bytes = 1];
 
   // The external authorization gRPC service configuration.
-  // Note: Only works with :ref:`Envoy's in-built gRPC client <envoy_api_msg_core.GrpcService.EnvoyGrpc>`
   envoy.api.v2.core.GrpcService grpc_service = 2;
 
   // The filter's behaviour in case the external authorization service does


### PR DESCRIPTION
_Title_
Fix up the comments for `failure_mode_allow` that was incorrectly worded and caught during review https://github.com/envoyproxy/envoy/pull/2416
cc: @junr03 

PS: I removed the comment about the restriction to only envoy_grpc client. That limitation is not really applicable based off the comment by Harvey in the PR#2416. Please do let me know if think it should be there.