### PR TITLE
Fix reference to using deprecated_v1 in tcp_proxy

### DIFF
--- a/envoy/config/filter/network/tcp_proxy/v2/tcp_proxy.proto
+++ b/envoy/config/filter/network/tcp_proxy/v2/tcp_proxy.proto
@@ -121,7 +121,7 @@ message TcpProxy {
   //   want to configure the filter using v1 config structure, please make this
   //   field a boolean with value ``true`` and configure via the opaque ``value`` field
   //   like is suggested in the filter `README
-  //   <https://github.com/envoyproxy/data-plane-api/blob/master/envoy/api/v2/filter/README.md>`_.
+  //   <https://github.com/envoyproxy/data-plane-api/blob/master/envoy/config/filter/README.md>`_.
   DeprecatedV1 deprecated_v1 = 6 [deprecated = true];
 
   // The maximum number of unsuccessful connection attempts that will be made before


### PR DESCRIPTION
The link wasn't quite correct for linking back to the filter
documentation. This PR just points it to the right place.