### PR TITLE
alternate redis healthcheck

### DIFF
--- a/docs/root/api-v1/cluster_manager/cluster_hc.rst
+++ b/docs/root/api-v1/cluster_manager/cluster_hc.rst
@@ -19,7 +19,8 @@ Health checking
     "send": [],
     "receive": [],
     "interval_jitter_ms": "...",
-    "service_name": "..."
+    "service_name": "...",
+    "redis_key": "..."
   }
 
 type
@@ -47,7 +48,7 @@ healthy_threshold
   a host healthy.
 
 path
-  *(sometimes required, string)* This parameter is required if the type is *http*. It species the
+  *(sometimes required, string)* This parameter is required if the type is *http*. It specifies the
   HTTP path that will be requested during health checking. For example */healthcheck*.
 
 send
@@ -80,3 +81,11 @@ service_name
   *(optional, string)* An optional service name parameter which is used to validate the identity of
   the health checked cluster. See the :ref:`architecture overview
   <arch_overview_health_checking_identity>` for more information.
+
+.. _config_cluster_manager_cluster_hc_redis_key:
+
+redis_key
+  *(optional, string)* If the type is *redis*, perform ``EXISTS <redis_key>`` instead of
+  ``PING``. A return value from Redis of 0 (does not exist) is considered a passing healthcheck. A
+  return value other than 0 is considered a failure. This allows the user to mark a Redis instance
+  for maintenance by setting the specified key to any value and waiting for traffic to drain.

--- a/docs/root/intro/arch_overview/health_checking.rst
+++ b/docs/root/intro/arch_overview/health_checking.rst
@@ -19,7 +19,10 @@ unhealthy, successes required before marking a host healthy, etc.):
   considered healthy. Envoy also supports connect only L3/L4 health checking.
 * **Redis**: Envoy will send a Redis PING command and expect a PONG response. The upstream Redis
   server can respond with anything other than PONG to cause an immediate active health check
-  failure.
+  failure. Optionally, Envoy can perform EXISTS on a user-specified key. If the key does not exist
+  it is considered a passing healthcheck. This allows the user to mark a Redis instance for
+  maintenance by setting the specified key to any value and waiting for traffic to drain. See
+  :ref:`redis_key <config_cluster_manager_cluster_hc_redis_key>`.
 
 Passive health checking
 -----------------------

--- a/envoy/api/v2/core/health_check.proto
+++ b/envoy/api/v2/core/health_check.proto
@@ -89,6 +89,11 @@ message HealthCheck {
   }
 
   message RedisHealthCheck {
+    // If set, optionally perform ``EXISTS <key>`` instead of ``PING``. A return value
+    // from Redis of 0 (does not exist) is considered a passing healthcheck. A return value other
+    // than 0 is considered a failure. This allows the user to mark a Redis instance for maintenance
+    // by setting the specified key to any value and waiting for traffic to drain.
+    string key = 1;
   }
 
   // `grpc.health.v1.Health


### PR DESCRIPTION
There is no way to modify the response of PING on a running Redis server without restarting it. This makes it painful to terminate an instance. All inflight requests plus requests until ejection by active or passive healthcheck will fail.