### PR TITLE
Add unauthorized boolean the accesslog.

### DIFF
--- a/envoy/config/filter/accesslog/v2/accesslog.proto
+++ b/envoy/config/filter/accesslog/v2/accesslog.proto
@@ -148,18 +148,18 @@ message ResponseFlags {
   // Indicates that the request was rate-limited locally.
   bool rate_limited = 12;
 
-  // Reasons why the request was unauthorized
-  enum UnauthorizedType {
-    // Default is permitted
-    PERMITTED = 0;
-    // The request was denied by the external authorization service.
-    EXTERNAL_SERVICE = 1;
+  message Unauthorized {
+    // Reasons why the request was unauthorized
+    enum UnauthorizedType {
+      UNAUTHORIZED_TYPE_UNSPECIFIED = 0;
+      // The request was denied by the external authorization service.
+      EXTERNAL_SERVICE = 1;
+    }
+
+    UnauthorizedType reason = 1;
   }
 
   // Indicates that the request was deemed unauthorized and denied.
-  message Unauthorized {
-    UnauthorizedType reason = 1;
-  }
   Unauthorized unauthorized_denied = 13;
 }
 

--- a/envoy/config/filter/accesslog/v2/accesslog.proto
+++ b/envoy/config/filter/accesslog/v2/accesslog.proto
@@ -150,14 +150,15 @@ message ResponseFlags {
 
   // Reasons why the request was unauthorized
   enum UnauthorizedType {
+    // Default is permitted
+    PERMITTED = 0;
     // The request was denied by the external authorization service.
-    EXTERNAL_SERVICE = 0;
+    EXTERNAL_SERVICE = 1;
   }
 
   // Indicates that the request was deemed unauthorized and denied.
   message Unauthorized {
-    bool is_unauthorized;
-    UnauthorizedType reason;
+    UnauthorizedType reason = 1;
   }
   Unauthorized unauthorized_denied = 13;
 }

--- a/envoy/config/filter/accesslog/v2/accesslog.proto
+++ b/envoy/config/filter/accesslog/v2/accesslog.proto
@@ -148,8 +148,18 @@ message ResponseFlags {
   // Indicates that the request was rate-limited locally.
   bool rate_limited = 12;
 
+  // Reasons why the request was unauthorized
+  enum UnauthorizedType {
+    // The request was denied by the external authorization service.
+    EXTERNAL_SERVICE = 0;
+  }
+
   // Indicates that the request was deemed unauthorized and denied.
-  bool unauthorized_denied = 13;
+  message Unauthorized {
+    bool is_unauthorized;
+    UnauthorizedType reason;
+  }
+  Unauthorized unauthorized_denied = 13;
 }
 
 // [#not-implemented-hide:] Not configuration. TBD how to doc proto APIs.

--- a/envoy/config/filter/accesslog/v2/accesslog.proto
+++ b/envoy/config/filter/accesslog/v2/accesslog.proto
@@ -147,6 +147,9 @@ message ResponseFlags {
 
   // Indicates that the request was rate-limited locally.
   bool rate_limited = 12;
+
+  // Indicates that the request was deemed unauthorized and denied.
+  bool unauthorized_denied = 13;
 }
 
 // [#not-implemented-hide:] Not configuration. TBD how to doc proto APIs.

--- a/envoy/config/filter/accesslog/v2/accesslog.proto
+++ b/envoy/config/filter/accesslog/v2/accesslog.proto
@@ -150,17 +150,17 @@ message ResponseFlags {
 
   message Unauthorized {
     // Reasons why the request was unauthorized
-    enum UnauthorizedType {
-      UNAUTHORIZED_TYPE_UNSPECIFIED = 0;
+    enum Reason {
+      REASON_UNSPECIFIED = 0;
       // The request was denied by the external authorization service.
       EXTERNAL_SERVICE = 1;
     }
 
-    UnauthorizedType reason = 1;
+    Reason reason = 1;
   }
 
-  // Indicates that the request was deemed unauthorized and denied.
-  Unauthorized unauthorized_denied = 13;
+  // Indicates if the request was deemed unauthorized and the reason for it.
+  Unauthorized unauthorized_details = 13;
 }
 
 // [#not-implemented-hide:] Not configuration. TBD how to doc proto APIs.


### PR DESCRIPTION
_Title_
In the proxy we've added an `Unauthorized` response flag. This PR adds the same to filter access logs.
Once this PR is merged it will be possible to set the flag in `source/common/access_log/grpc_access_log_impl.cc`
See also, comment in https://github.com/envoyproxy/envoy/pull/2415

cc: @htuch
Signed-off-by: Saurabh Mohan <saurabh+github@tigera.io>