### PR TITLE
docs:fix doc links

### DIFF
--- a/XDS_PROTOCOL.md
+++ b/XDS_PROTOCOL.md
@@ -98,7 +98,7 @@ messages:
 The version provides Envoy and the management server a shared notion of the
 currently applied configuration, as well as a mechanism to ACK/NACK
 configuration updates. If Envoy had instead rejected configuration update __X__,
-it would reply with 
+it would reply with
 [`error_detail`](https://www.envoyproxy.io/docs/envoy/latest/api-v2/api/v2/discovery.proto#envoy-api-field-discoveryrequest-error-detail)
 populated and its previous version, which in this case was the empty
 initial version. The error_detail has more details around the exact error message

--- a/XDS_PROTOCOL.md
+++ b/XDS_PROTOCOL.md
@@ -98,7 +98,8 @@ messages:
 The version provides Envoy and the management server a shared notion of the
 currently applied configuration, as well as a mechanism to ACK/NACK
 configuration updates. If Envoy had instead rejected configuration update __X__,
-it would reply with [`error_detail`] (https://www.envoyproxy.io/docs/envoy/latest/api-v2/api/v2/discovery.proto#envoy-api-field-discoveryrequest-error-detail)
+it would reply with 
+[`error_detail`](https://www.envoyproxy.io/docs/envoy/latest/api-v2/api/v2/discovery.proto#envoy-api-field-discoveryrequest-error-detail)
 populated and its previous version, which in this case was the empty
 initial version. The error_detail has more details around the exact error message
 populated in the message field:

--- a/tools/protodoc/protodoc.py
+++ b/tools/protodoc/protodoc.py
@@ -24,6 +24,9 @@ ENVOY_PREFIX = '.envoy.'
 # Namespace prefix for WKTs.
 WKT_NAMESPACE_PREFIX = '.google.protobuf.'
 
+# Namespace prefix for RPCs.
+RPC_NAMESPACE_PREFIX = '.google.rpc.'
+
 # http://www.fileformat.info/info/unicode/char/2063/index.htm
 UNICODE_INVISIBLE_SEPARATOR = u'\u2063'
 
@@ -433,6 +436,12 @@ def FormatFieldType(type_context, field):
         wkt,
         'https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#%s'
         % wkt.lower())
+  elif field.type_name.startswith(RPC_NAMESPACE_PREFIX):
+    rpc = field.type_name[len(RPC_NAMESPACE_PREFIX):]
+    return FormatExternalLink(
+        rpc,
+        'https://cloud.google.com/natural-language/docs/reference/rpc/google.rpc#%s'
+        % rpc.lower())
   elif field.type_name:
     return field.type_name
 


### PR DESCRIPTION
Signed-off-by: Rama <rama.rao@salesforce.com>

@htuch looks like the doc link for `error_detail` because of line spacing. Corrected that and also `grpc.rpc.Status` link is not coming. Changed the .py file add this. PTAL.