### PR TITLE
Document cert forwarding in the XFCC header.

### DIFF
--- a/envoy/config/filter/network/http_connection_manager/v2/http_connection_manager.proto
+++ b/envoy/config/filter/network/http_connection_manager/v2/http_connection_manager.proto
@@ -212,8 +212,9 @@ message HttpConnectionManager {
     // Whether to forward the SAN of the client cert. Defaults to false.
     google.protobuf.BoolValue san = 2;
 
-    // [#not-implemented-hide:]
-    // Whether to forward the entire client cert in base64 encoded format. Defaults to false.
+    // Whether to forward the entire client cert in URL encoded PEM format. This will appear in the
+    // XFCC header comma separated from other values with the value Cert="PEM".
+    // Defaults to false.
     bool cert = 3;
   };
 


### PR DESCRIPTION
I was having trouble generating docs locally `./docs/build.sh: line 92: sphinx-build: command not found`.  It also wasn't totally clear if I should only be documenting this in the protofile and then it would be picked up by the v2 docs, or if I should also be documenting this in rst files in the v1 documentation folders.  If this isn't enough, please let me know and I'll improve things.