### PR TITLE
Add java_generic_services option to service proto files

### DIFF
--- a/envoy/api/v2/cds.proto
+++ b/envoy/api/v2/cds.proto
@@ -2,6 +2,8 @@ syntax = "proto3";
 
 package envoy.api.v2;
 
+option java_generic_services = true;
+
 import "envoy/api/v2/core/address.proto";
 import "envoy/api/v2/auth/cert.proto";
 import "envoy/api/v2/core/base.proto";

--- a/envoy/api/v2/eds.proto
+++ b/envoy/api/v2/eds.proto
@@ -2,6 +2,8 @@ syntax = "proto3";
 
 package envoy.api.v2;
 
+option java_generic_services = true;
+
 import "envoy/api/v2/discovery.proto";
 import "envoy/api/v2/endpoint/endpoint.proto";
 

--- a/envoy/api/v2/lds.proto
+++ b/envoy/api/v2/lds.proto
@@ -2,6 +2,8 @@ syntax = "proto3";
 
 package envoy.api.v2;
 
+option java_generic_services = true;
+
 import "envoy/api/v2/core/address.proto";
 import "envoy/api/v2/core/base.proto";
 import "envoy/api/v2/discovery.proto";

--- a/envoy/api/v2/rds.proto
+++ b/envoy/api/v2/rds.proto
@@ -2,6 +2,8 @@ syntax = "proto3";
 
 package envoy.api.v2;
 
+option java_generic_services = true;
+
 import "envoy/api/v2/core/base.proto";
 import "envoy/api/v2/discovery.proto";
 import "envoy/api/v2/route/route.proto";

--- a/envoy/api/v2/route/route.proto
+++ b/envoy/api/v2/route/route.proto
@@ -2,6 +2,7 @@ syntax = "proto3";
 
 package envoy.api.v2.route;
 option go_package = "route";
+option java_generic_services = true;
 
 import "envoy/api/v2/core/base.proto";
 import "envoy/api/v2/auth/auth.proto";

--- a/envoy/service/accesslog/v2/als.proto
+++ b/envoy/service/accesslog/v2/als.proto
@@ -2,6 +2,7 @@ syntax = "proto3";
 
 package envoy.service.accesslog.v2;
 option go_package = "v2";
+option java_generic_services = true;
 
 import "envoy/api/v2/core/base.proto";
 import "envoy/config/filter/accesslog/v2/accesslog.proto";

--- a/envoy/service/auth/v2/external_auth.proto
+++ b/envoy/service/auth/v2/external_auth.proto
@@ -4,6 +4,7 @@ syntax = "proto3";
 
 package envoy.service.auth.v2;
 option go_package = "v2";
+option java_generic_services = true;
 
 import "envoy/service/auth/v2/attribute_context.proto";
 

--- a/envoy/service/discovery/v2/ads.proto
+++ b/envoy/service/discovery/v2/ads.proto
@@ -2,6 +2,7 @@ syntax = "proto3";
 
 package envoy.service.discovery.v2;
 option go_package = "v2";
+option java_generic_services = true;
 
 import "envoy/api/v2/discovery.proto";
 

--- a/envoy/service/discovery/v2/hds.proto
+++ b/envoy/service/discovery/v2/hds.proto
@@ -2,6 +2,8 @@ syntax = "proto3";
 
 package envoy.service.discovery.v2;
 
+option java_generic_services = true;
+
 import "envoy/api/v2/core/base.proto";
 import "envoy/api/v2/core/health_check.proto";
 import "envoy/api/v2/endpoint/endpoint.proto";

--- a/envoy/service/load_stats/v2/lrs.proto
+++ b/envoy/service/load_stats/v2/lrs.proto
@@ -2,6 +2,7 @@ syntax = "proto3";
 
 package envoy.service.load_stats.v2;
 option go_package = "v2";
+option java_generic_services = true;
 
 import "envoy/api/v2/core/base.proto";
 import "envoy/api/v2/endpoint/load_report.proto";

--- a/envoy/service/metrics/v2/metrics_service.proto
+++ b/envoy/service/metrics/v2/metrics_service.proto
@@ -4,6 +4,7 @@ syntax = "proto3";
 
 package envoy.service.metrics.v2;
 option go_package = "v2";
+option java_generic_services = true;
 
 import "envoy/api/v2/core/base.proto";
 

--- a/envoy/service/trace/v2/trace_service.proto
+++ b/envoy/service/trace/v2/trace_service.proto
@@ -4,6 +4,7 @@ syntax = "proto3";
 
 package envoy.service.trace.v2;
 option go_package = "v2";
+option java_generic_services = true;
 
 import "envoy/api/v2/core/base.proto";
 import "trace.proto";


### PR DESCRIPTION
This enables generating generic service stubs for all the data-plane-api
proto services when generating Java classes with protoc.

This is generally not needed when implementing a gRPC server but in our case we're implementing
it behind our legacy protobuf RPC framework which rely on these stubs. As far as I know the only negative
with enabling these is generating some potentially unnecessary Java classes. 