### PR TITLE
go: add equals to percent

### DIFF
--- a/envoy/type/percent.proto
+++ b/envoy/type/percent.proto
@@ -5,6 +5,9 @@ package envoy.type;
 import "google/protobuf/wrappers.proto";
 
 import "validate/validate.proto";
+import "gogoproto/gogo.proto";
+
+option (gogoproto.equal_all) = true;
 
 // [#protodoc-title: Percent]
 


### PR DESCRIPTION
Missing another Equals annotation from a type.
It might be worth enabling Equals for the entire API, to avoid patching this frequently. 

Signed-off-by: Kuat Yessenov <kuat@google.com>