### PR TITLE
lds: Add "transparent" option to support iptables TPROXY in listeners

### DIFF
--- a/docs/root/configuration/access_log.rst
+++ b/docs/root/configuration/access_log.rst
@@ -135,6 +135,8 @@ The following command operators are supported:
   If the original connection was redirected by iptables REDIRECT, this represents
   the original destination address restored by the
   :ref:`Original Destination Filter <config_listener_filters_original_dst>` using SO_ORIGINAL_DST socket option.
+  If the original connection was redirected by iptables TPROXY, and the listener's transparent
+  option was set to true, this represents the original destination address and port.
 
 %DOWNSTREAM_LOCAL_ADDRESS_WITHOUT_PORT%
     Same as **%DOWNSTREAM_LOCAL_ADDRESS%** excluding port if the address is an IP address.

--- a/docs/root/configuration/http_conn_man/headers.rst
+++ b/docs/root/configuration/http_conn_man/headers.rst
@@ -454,6 +454,8 @@ Supported variable names are:
     If the original connection was redirected by iptables REDIRECT, this represents
     the original destination address restored by the
     :ref:`Original Destination Filter <config_listener_filters_original_dst>` using SO_ORIGINAL_DST socket option.
+    If the original connection was redirected by iptables TPROXY, and the listener's transparent
+    option was set to true, this represents the original destination address and port.
 
 %DOWNSTREAM_LOCAL_ADDRESS_WITHOUT_PORT%
     Same as **%DOWNSTREAM_LOCAL_ADDRESS%** excluding port if the address is an IP address.

--- a/docs/root/intro/arch_overview/service_discovery.rst
+++ b/docs/root/intro/arch_overview/service_discovery.rst
@@ -57,10 +57,10 @@ Original destination
 ^^^^^^^^^^^^^^^^^^^^
 
 Original destination cluster can be used when incoming connections are redirected to Envoy either
-via an iptables REDIRECT rule or with Proxy Protocol. In these cases requests routed to an original
-destination cluster are forwarded to upstream hosts as addressed by the redirection metadata,
-without any explicit host configuration or upstream host discovery. Connections to upstream hosts
-are pooled and unused hosts are flushed out when they have been idle longer than
+via an iptables REDIRECT or TPROXY target or with Proxy Protocol. In these cases requests routed
+to an original destination cluster are forwarded to upstream hosts as addressed by the redirection
+metadata, without any explicit host configuration or upstream host discovery. Connections to
+upstream hosts are pooled and unused hosts are flushed out when they have been idle longer than
 :ref:`*cleanup_interval_ms* <config_cluster_manager_cluster_cleanup_interval_ms>`, which defaults to
 5000ms. If the original destination address is is not available, no upstream connection is opened.
 Original destination service discovery must be used with the original destination :ref:`load

--- a/envoy/api/v2/lds.proto
+++ b/envoy/api/v2/lds.proto
@@ -129,7 +129,7 @@ message Listener {
 
   // Whether the listener should be set as a transparent socket. When this flag is set to true,
   // connections can be redirected to the listener using an *iptables* *TPROXY* target, in which
-  // case the original source and destination addresses and ports are preserved on acccepted
+  // case the original source and destination addresses and ports are preserved on accepted
   // connections. Requires Envoy to run with the *CAP_NET_ADMIN* capability. Defaults to false.
   google.protobuf.BoolValue transparent = 10;
 }

--- a/envoy/api/v2/lds.proto
+++ b/envoy/api/v2/lds.proto
@@ -131,5 +131,5 @@ message Listener {
   // connections can be redirected to the listener using an *iptables* *TPROXY* target, in which
   // case the original source and destination addresses and ports are preserved on accepted
   // connections. Requires Envoy to run with the *CAP_NET_ADMIN* capability. Defaults to false.
-  google.protobuf.BoolValue transparent = 10;
+  bool transparent = 10;
 }

--- a/envoy/api/v2/lds.proto
+++ b/envoy/api/v2/lds.proto
@@ -126,4 +126,10 @@ message Listener {
   // filters are processed sequentially right after a socket has been accepted by the listener, and
   // before a connection is created.
   repeated listener.ListenerFilter listener_filters = 9 [(gogoproto.nullable) = false];
+
+  // Whether the listener should be set as a transparent socket. When this flag is set to true,
+  // connections can be redirected to the listener using an *iptables* *TPROXY* target, in which
+  // case the original source and destination addresses and ports are preserved on acccepted
+  // connections. Requires Envoy to run with the *CAP_NET_ADMIN* capability. Defaults to false.
+  google.protobuf.BoolValue transparent = 10;
 }


### PR DESCRIPTION
Add a "transparent" option to Listener to set the SOL_IP/IP_TRANSPARENT option on listen sockets, which allows using Envoy with the iptables TPROXY target.
Unlike the iptables REDIRECT target, TPROXY allows preserving both the source and destination IP addresses and ports of accepted connections.

API changes for: https://github.com/envoyproxy/envoy/pull/2719

Signed-off-by: Romain Lenglet <romain@covalent.io>