### PR TITLE
Add a lazy loading configuration field to bootstrap.proto

### DIFF
--- a/envoy/config/bootstrap/v2/bootstrap.proto
+++ b/envoy/config/bootstrap/v2/bootstrap.proto
@@ -58,6 +58,9 @@ message Bootstrap {
     // configuration source.
     envoy.api.v2.core.ConfigSource cds_config = 2;
 
+    // A CDS config used for the ClusterManager's Lazy loading functionality.
+    envoy.api.v2.core.ConfigSource lazy_load_cds_config = 5;
+
     // A single :ref:`ADS <config_overview_v2_ads>` source may be optionally
     // specified. This must have :ref:`api_type
     // <envoy_api_field_core.ApiConfigSource.api_type>` :ref:`GRPC


### PR DESCRIPTION
This proposal adds a configuration field to enable Cluster lazy loading as described in https://github.com/envoyproxy/envoy/issues/2500

The current pending pull request https://github.com/envoyproxy/envoy/pull/2740 does not have a way to be explicitly configured at the moment.

If this PR is approved I will update https://github.com/envoyproxy/envoy/pull/2740