### PR TITLE
docs: weighted cluster route manipulation

### DIFF
--- a/docs/root/configuration/http_conn_man/headers.rst
+++ b/docs/root/configuration/http_conn_man/headers.rst
@@ -411,13 +411,13 @@ The encode one or more options. For example, Debug is encoded as
 Custom request/response headers
 -------------------------------
 
-Custom request/response headers can be added to a request/response that matches a specific route at
-the route, virtual host, and global route configuration level. See the relevant :ref:`v1
+Custom request/response headers can be added to a request/response at the weighted cluster,
+route, virtual host, and/or global route configuration level. See the relevant :ref:`v1
 <config_http_conn_man_route_table>` and :ref:`v2 <envoy_api_msg_RouteConfiguration>` API
 documentation.
 
-Headers are appended to requests/responses in the following order: route level headers,
-virtual host level headers and finally global level headers.
+Headers are appended to requests/responses in the following order: weighted cluster level headers,
+route level headers, virtual host level headers and finally global level headers.
 
 Envoy supports adding dynamic values to request and response headers. The percent symbol (%) is
 used to delimit variable names.

--- a/envoy/api/v2/route/route.proto
+++ b/envoy/api/v2/route/route.proto
@@ -163,7 +163,6 @@ message WeightedCluster {
     // considered. The filter name should be specified as *envoy.lb*.
     core.Metadata metadata_match = 3;
 
-    // [#not-implemented-hide:]
     // Specifies a list of headers to be added to requests when this cluster is selected
     // through the enclosing :ref:`envoy_api_msg_route.RouteAction`.
     // Headers specified at this level are applied before headers from the enclosing
@@ -174,7 +173,6 @@ message WeightedCluster {
     // <config_http_conn_man_headers_custom_request_headers>`.
     repeated core.HeaderValueOption request_headers_to_add = 4;
 
-    // [#not-implemented-hide:]
     // Specifies a list of headers to be added to responses when this cluster is selected
     // through the enclosing :ref:`envoy_api_msg_route.RouteAction`.
     // Headers specified at this level are applied before headers from the enclosing
@@ -185,7 +183,6 @@ message WeightedCluster {
     // <config_http_conn_man_headers_custom_request_headers>`.
     repeated core.HeaderValueOption response_headers_to_add = 5;
 
-    // [#not-implemented-hide:]
     // Specifies a list of headers to be removed from responses when this cluster is selected
     // through the enclosing :ref:`envoy_api_msg_route.RouteAction`.
     repeated string response_headers_to_remove = 6;

--- a/envoy/api/v2/route/route.proto
+++ b/envoy/api/v2/route/route.proto
@@ -90,7 +90,7 @@ message VirtualHost {
   repeated core.HeaderValueOption response_headers_to_add = 10;
 
   // Specifies a list of HTTP headers that should be removed from each response
-  // handle by this virtual host.
+  // handled by this virtual host.
   repeated string response_headers_to_remove = 11;
 
   // Indicates that the virtual host has a CORS policy.
@@ -168,7 +168,7 @@ message WeightedCluster {
     // Headers specified at this level are applied before headers from the enclosing
     // :ref:`envoy_api_msg_route.RouteAction`,
     // :ref:`envoy_api_msg_route.VirtualHost`, and
-    // :ref:`envoy_api_msg_route.RouteConfiguration`. For more information, including details on
+    // :ref:`envoy_api_msg_RouteConfiguration`. For more information, including details on
     // header value syntax, see the documentation on :ref:`custom request headers
     // <config_http_conn_man_headers_custom_request_headers>`.
     repeated core.HeaderValueOption request_headers_to_add = 4;
@@ -178,7 +178,7 @@ message WeightedCluster {
     // Headers specified at this level are applied before headers from the enclosing
     // :ref:`envoy_api_msg_route.RouteAction`,
     // :ref:`envoy_api_msg_route.VirtualHost`, and
-    // :ref:`envoy_api_msg_route.RouteConfiguration`. For more information, including details on
+    // :ref:`envoy_api_msg_RouteConfiguration`. For more information, including details on
     // header value syntax, see the documentation on :ref:`custom request headers
     // <config_http_conn_man_headers_custom_request_headers>`.
     repeated core.HeaderValueOption response_headers_to_add = 5;


### PR DESCRIPTION
Unhide the `request_headers_to_add`, `response_headers_to_add`, and `response_headers_to_remove` fields in ClusterWeight. Update HTTP conn manager docs related to same.

Doc update for envoyproxy/envoy#2765.

Signed-off-by: Stephan Zuercher <stephan@turbinelabs.io>