### PR TITLE
lds,BindConfig: Add "freebind" options to support IP_FREEBIND.

### DIFF
--- a/envoy/api/v2/core/address.proto
+++ b/envoy/api/v2/core/address.proto
@@ -62,6 +62,11 @@ message BindConfig {
   // The address to bind to when creating a socket.
   SocketAddress source_address = 1
       [(validate.rules).message.required = true, (gogoproto.nullable) = false];
+
+  // [#not-implemented-hide:] Whether to set the IP_FREEBIND option when creating the socket. If
+  // set, allows the source_address specified to be an address that is not configured on the system
+  // running Envoy. Defaults to false.
+  bool freebind = 2;
 }
 
 // Addresses specify either a logical or physical address and port, which are

--- a/envoy/api/v2/lds.proto
+++ b/envoy/api/v2/lds.proto
@@ -132,4 +132,9 @@ message Listener {
   // case the original source and destination addresses and ports are preserved on accepted
   // connections. Requires Envoy to run with the *CAP_NET_ADMIN* capability. Defaults to false.
   bool transparent = 10;
+
+  // [#not-implemented-hide:] Whether the listener should set the IP_FREEBIND socket option. When
+  // this flag is set to true listeners can be bound to an IP address that is not configured on the
+  // system running Envoy. Defaults to false.
+  bool freebind = 11;
 }


### PR DESCRIPTION
Add an option "freebind" in LDS for listeners and the BindConfig which
is used for outgoing upstream connections. If true, set the IP_FREEBIND
socket option. Defaults to false.

PR description will be updated with Envoy implementation PR# once it is
created. Currently hidden as not implemented.

Signed-off-by: Dan Noé <dpn@google.com>