### PR TITLE
docs: add documents about tagged metrics

### DIFF
--- a/docs/root/intro/arch_overview/statistics.rst
+++ b/docs/root/intro/arch_overview/statistics.rst
@@ -10,7 +10,7 @@ of statistics depending on how it is configured. Generally the statistics fall i
   listeners, the HTTP connection manager, the TCP proxy filter, etc.
 * **Upstream**: Upstream statistics relate to outgoing connections/requests. They are emitted by
   connection pools, the router filter, the TCP proxy filter, etc.
-* **Server**: Server statistics describes how the Envoy server instance is working. Statistics like
+* **Server**: Server statistics describe how the Envoy server instance is working. Statistics like
   server uptime or amount of allocated memory are categorized here.
 
 A single proxy scenario typically involves both downstream and upstream statistics. The two types

--- a/docs/root/intro/arch_overview/statistics.rst
+++ b/docs/root/intro/arch_overview/statistics.rst
@@ -31,8 +31,8 @@ Envoy emits three types of values as statistics:
 
 * **Counters**: Unsigned integers that only increase and never decrease. E.g., total requests.
 * **Gauges**: Unsigned integers that both increase and decrease. E.g., currently active requests.
-* **Histograms**: Unsigned integers that ultimately will yield summarized percentile values. E.g.,
-  upstream request time.
+* **Histograms**: Unsigned integers that are part of a stream of values that are then aggregated by
+  the collector to ultimately yield summarized percentile values. E.g., upstream request time.
 
 Internally, counters and gauges are batched and periodically flushed to improve performance.
 Histograms are written as they are received. Note: what were previously referred to as timers have

--- a/docs/root/intro/arch_overview/statistics.rst
+++ b/docs/root/intro/arch_overview/statistics.rst
@@ -23,7 +23,11 @@ are supported. As of the v2 API, Envoy has the ability to support custom, plugga
 standard sink implementations are included in Envoy. Some sinks also support emitting statistics
 with tags/dimensions.
 
-Envoy emits three types of values as statistics:
+Envoy's tagged statistics have the following characteristic. Within Envoy, statistics have canonical
+string representations as their name. The statistic name is dynamically stripped to produce tags.
+Users can configure the behavior via Tag Specifier configuration.
+
+Those three types of values are emitted as statistics:
 
 * **Counters**: Unsigned integers that only increase and never decrease. E.g., total requests.
 * **Gauges**: Unsigned integers that both increase and decrease. E.g., currently active requests.

--- a/docs/root/intro/arch_overview/statistics.rst
+++ b/docs/root/intro/arch_overview/statistics.rst
@@ -25,7 +25,7 @@ with tags/dimensions.
 
 Within Envoy and throughout the documentation, statistics are identified by a canonical string
 representation. The dynamic portions of these strings are stripped to become tags. Users can
-configure this behavior via the Tag Specifier configuration.
+configure this behavior via :ref:`the Tag Specifier configuration <envoy_api_msg_config.metrics.v2.TagSpecifier>`.
 
 Envoy emits three types of values as statistics:
 

--- a/docs/root/intro/arch_overview/statistics.rst
+++ b/docs/root/intro/arch_overview/statistics.rst
@@ -27,7 +27,7 @@ Within Envoy and throughout the documentation, statistics are identified by a ca
 representation. The dynamic portions of these strings are stripped to become tags. Users can
 configure this behavior via the Tag Specifier configuration.
 
-Those three types of values are emitted as statistics:
+Envoy emits three types of values as statistics:
 
 * **Counters**: Unsigned integers that only increase and never decrease. E.g., total requests.
 * **Gauges**: Unsigned integers that both increase and decrease. E.g., currently active requests.

--- a/docs/root/intro/arch_overview/statistics.rst
+++ b/docs/root/intro/arch_overview/statistics.rst
@@ -19,9 +19,9 @@ mesh give a very detailed picture of each hop and overall network health. The st
 documented in detail in the operations guide.
 
 In the v1 API, Envoy only supports statsd as the statistics output format. Both TCP and UDP statsd
-are supported. Since Envoy has plugging mechanism to support different statistics sinks, as of v2
-API, multiple stats sinks are supported. Some of them emit tagged/multiple dimentions statistics.
-They are documented in detail in the configuration guide.
+are supported. As of the v2 API, Envoy has the ability to support custom, pluggable sinks. A few
+standard sink implementations are included in Envoy. Some sinks also support emitting statistics
+with tags/dimensions.
 
 Envoy emits three types of values as statistics:
 

--- a/docs/root/intro/arch_overview/statistics.rst
+++ b/docs/root/intro/arch_overview/statistics.rst
@@ -18,7 +18,7 @@ can be used to get a detailed picture of that particular network hop. Statistics
 mesh give a very detailed picture of each hop and overall network health. The statistics emitted are
 documented in detail in the operations guide.
 
-In v1 API, Envoy only supports statsd as the statistics output format. Both TCP and UDP statsd
+In the v1 API, Envoy only supports statsd as the statistics output format. Both TCP and UDP statsd
 are supported. Since Envoy has plugging mechanism to support different statistics sinks, as of v2
 API, multiple stats sinks are supported. Some of them emit tagged/multiple dimentions statistics.
 They are documented in detail in the configuration guide.

--- a/docs/root/intro/arch_overview/statistics.rst
+++ b/docs/root/intro/arch_overview/statistics.rst
@@ -4,12 +4,14 @@ Statistics
 ==========
 
 One of the primary goals of Envoy is to make the network understandable. Envoy emits a large number
-of statistics depending on how it is configured. Generally the statistics fall into two categories:
+of statistics depending on how it is configured. Generally the statistics fall into three categories:
 
 * **Downstream**: Downstream statistics relate to incoming connections/requests. They are emitted by
   listeners, the HTTP connection manager, the TCP proxy filter, etc.
 * **Upstream**: Upstream statistics relate to outgoing connections/requests. They are emitted by
   connection pools, the router filter, the TCP proxy filter, etc.
+* **Server**: Server statistics describes how the Envoy server instance is working. Statistics like
+  server uptime or amount of allocated memory are categorized here.
 
 A single proxy scenario typically involves both downstream and upstream statistics. The two types
 can be used to get a detailed picture of that particular network hop. Statistics from the entire

--- a/docs/root/intro/arch_overview/statistics.rst
+++ b/docs/root/intro/arch_overview/statistics.rst
@@ -23,9 +23,9 @@ are supported. As of the v2 API, Envoy has the ability to support custom, plugga
 standard sink implementations are included in Envoy. Some sinks also support emitting statistics
 with tags/dimensions.
 
-Envoy's tagged statistics have the following characteristic. Within Envoy, statistics have canonical
-string representations as their name. The statistic name is dynamically stripped to produce tags.
-Users can configure the behavior via Tag Specifier configuration.
+Within Envoy and throughout the documentation, statistics are identified by a canonical string
+representation. The dynamic portions of these strings are stripped to become tags. Users can
+configure this behavior via the Tag Specifier configuration.
 
 Those three types of values are emitted as statistics:
 

--- a/docs/root/intro/arch_overview/statistics.rst
+++ b/docs/root/intro/arch_overview/statistics.rst
@@ -23,6 +23,13 @@ are supported. Since Envoy has plugging mechanism to support different statistic
 API, multiple stats sinks are supported. Some of them emit tagged/multiple dimentions statistics.
 They are documented in detail in the configuration guide.
 
+Envoy emits three types of values as statistics:
+
+* **Counters**: Unsigned integers that only increase and never decrease. E.g., total requests.
+* **Gauges**: Unsigned integers that both increase and decrease. E.g., currently active requests.
+* **Histograms**: Unsigned integers that ultimately will yield summarized percentile values. E.g.,
+  upstream request time.
+
 Internally, counters and gauges are batched and periodically flushed to improve performance.
 Histograms are written as they are received. Note: what were previously referred to as timers have
 become histograms as the only difference between the two representations was the units.

--- a/docs/root/intro/arch_overview/statistics.rst
+++ b/docs/root/intro/arch_overview/statistics.rst
@@ -19,9 +19,9 @@ mesh give a very detailed picture of each hop and overall network health. The st
 documented in detail in the operations guide.
 
 In the v1 API, Envoy only supports statsd as the statistics output format. Both TCP and UDP statsd
-are supported. As of the v2 API, Envoy has the ability to support custom, pluggable sinks. A few
-standard sink implementations are included in Envoy. Some sinks also support emitting statistics
-with tags/dimensions.
+are supported. As of the v2 API, Envoy has the ability to support custom, pluggable sinks. :ref:`A
+few standard sink implementations<envoy_api_msg_config.metrics.v2.StatsSink>` are included in Envoy.
+Some sinks also support emitting statistics with tags/dimensions.
 
 Within Envoy and throughout the documentation, statistics are identified by a canonical string
 representation. The dynamic portions of these strings are stripped to become tags. Users can

--- a/docs/root/intro/arch_overview/statistics.rst
+++ b/docs/root/intro/arch_overview/statistics.rst
@@ -16,11 +16,14 @@ can be used to get a detailed picture of that particular network hop. Statistics
 mesh give a very detailed picture of each hop and overall network health. The statistics emitted are
 documented in detail in the operations guide.
 
-Envoy uses statsd as the statistics output format, though plugging in a different statistics sink
-would not be difficult. Both TCP and UDP statsd is supported. Internally, counters and gauges are
-batched and periodically flushed to improve performance. Histograms are written as they are
-received. Note: what were previously referred to as timers have become histograms as the only
-difference between the two representations was the units.
+In v1 API, Envoy only supports statsd as the statistics output format. Both TCP and UDP statsd
+are supported. Since Envoy has plugging mechanism to support different statistics sinks, as of v2
+API, multiple stats sinks are supported. Some of them emit tagged/multiple dimentions statistics.
+They are documented in detail in the configuration guide.
+
+Internally, counters and gauges are batched and periodically flushed to improve performance.
+Histograms are written as they are received. Note: what were previously referred to as timers have
+become histograms as the only difference between the two representations was the units.
 
 * :ref:`v1 API reference <config_overview_v1>`.
 * :ref:`v2 API reference <envoy_api_field_config.bootstrap.v2.Bootstrap.stats_sinks>`.

--- a/envoy/config/metrics/v2/stats.proto
+++ b/envoy/config/metrics/v2/stats.proto
@@ -22,7 +22,7 @@ message StatsSink {
   // * :ref:`envoy.dog_statsd <envoy_api_msg_config.metrics.v2.DogStatsdSink>`
   // * :ref:`envoy.metrics_service <envoy_api_msg_config.metrics.v2.MetricsServiceConfig>`
   //
-  // Sinks optionally support tagged/multiple dimensions metrics.
+  // Sinks optionally support tagged/multiple dimensional metrics.
   string name = 1;
 
   // Stats sink specific configuration which depends on the sink being

--- a/envoy/config/metrics/v2/stats.proto
+++ b/envoy/config/metrics/v2/stats.proto
@@ -22,7 +22,7 @@ message StatsSink {
   // * :ref:`envoy.dog_statsd <envoy_api_msg_config.metrics.v2.DogStatsdSink>`
   // * :ref:`envoy.metrics_service <envoy_api_msg_config.metrics.v2.MetricsServiceConfig>`
   //
-  // Sinks optionally support tagged/multiple dimension metrics.
+  // Sinks optionally support tagged/multiple dimensions metrics.
   string name = 1;
 
   // Stats sink specific configuration which depends on the sink being

--- a/envoy/config/metrics/v2/stats.proto
+++ b/envoy/config/metrics/v2/stats.proto
@@ -22,7 +22,7 @@ message StatsSink {
   // * :ref:`envoy.dog_statsd <envoy_api_msg_config.metrics.v2.DogStatsdSink>`
   // * :ref:`envoy.metrics_service <envoy_api_msg_config.metrics.v2.MetricsServiceConfig>`
   //
-  // Some sinks support tagged/multiple dimentions metrics and some do not.
+  // Sinks optionally support tagged/multiple dimension metrics.
   string name = 1;
 
   // Stats sink specific configuration which depends on the sink being

--- a/envoy/config/metrics/v2/stats.proto
+++ b/envoy/config/metrics/v2/stats.proto
@@ -21,6 +21,8 @@ message StatsSink {
   // * :ref:`envoy.statsd <envoy_api_msg_config.metrics.v2.StatsdSink>`
   // * :ref:`envoy.dog_statsd <envoy_api_msg_config.metrics.v2.DogStatsdSink>`
   // * :ref:`envoy.metrics_service <envoy_api_msg_config.metrics.v2.MetricsServiceConfig>`
+  //
+  // Some sinks support tagged/multiple dimentions metrics and some do not.
   string name = 1;
 
   // Stats sink specific configuration which depends on the sink being
@@ -137,7 +139,8 @@ message TagSpecifier {
   }
 }
 
-// Stats configuration proto schema for built-in *envoy.statsd* sink.
+// Stats configuration proto schema for built-in *envoy.statsd* sink. This sink does not support
+// tagged metrics.
 message StatsdSink {
   oneof statsd_specifier {
     option (validate.required) = true;


### PR DESCRIPTION
Fixes https://github.com/envoyproxy/envoy/issues/2538

As discussed at https://github.com/envoyproxy/envoy/issues/2538#issuecomment-363493241, tagged metrics/statics should be coverd in the archtecture overview, since most uses start from it. I added some v1/v2 differences about stats sinks in arch overview and left the configuration page to describe which sink supports tagged metrics because we will have more sinks.

This is a draft one and any comments are welcomed about both the content and English matters.

cc @mrice32 