### PR TITLE
docs: drop unnecessary field in DogStatsdSink message

### DIFF
--- a/envoy/config/metrics/v2/stats.proto
+++ b/envoy/config/metrics/v2/stats.proto
@@ -158,6 +158,7 @@ message StatsdSink {
 // The sink emits stats with `DogStatsD <https://docs.datadoghq.com/guides/dogstatsd/>`_
 // compatible tags. Tags are configurable via :ref:`StatsConfig
 // <envoy_api_msg_config.metrics.v2.StatsConfig>`.
+// [#comment:next free field: 3]
 message DogStatsdSink {
   oneof dog_statsd_specifier {
     option (validate.required) = true;

--- a/envoy/config/metrics/v2/stats.proto
+++ b/envoy/config/metrics/v2/stats.proto
@@ -165,9 +165,5 @@ message DogStatsdSink {
     // The UDP address of a running DogStatsD compliant listener. If specified,
     // statistics will be flushed to this address.
     envoy.api.v2.core.Address address = 1;
-
-    // The name of a cluster that is DogStatsD compliant TCP listener. If specified,
-    // Envoy will connect to this cluster to flush statistics.
-    string tcp_cluster_name = 2;
   }
 }

--- a/envoy/config/metrics/v2/stats.proto
+++ b/envoy/config/metrics/v2/stats.proto
@@ -167,4 +167,6 @@ message DogStatsdSink {
     // statistics will be flushed to this address.
     envoy.api.v2.core.Address address = 1;
   }
+
+  reserved 2;
 }


### PR DESCRIPTION
This is a follow-up PR of https://github.com/envoyproxy/data-plane-api/pull/325.
I mistook to add an unnecessary field [here](https://github.com/envoyproxy/data-plane-api/pull/325#discussion_r155102953). What actually we need is just making `dog_statsd_specifier` `oneof` field, not adding `tcp_cluster_name` field.

We can safely drop this field because users has ended up with
initializing errors if they had specified this field.

```
[critical][main] source/server/server.cc:71] error initializing configuration '/envoy.yaml': Address must be a socket or pipe
```

This field has
never been used in envoy repo: https://github.com/envoyproxy/envoy/blob/7d03b231c7e8e086956096f6ca961f82c684ed0b/source/server/config/stats/dog_statsd.cc#L19-L23

Signed-off-by: Taiki Ono <taiki-ono@cookpad.com>