### PR TITLE
tcp proxy: Remove not-implemented for metadata_match

### DIFF
--- a/envoy/config/filter/network/tcp_proxy/v2/tcp_proxy.proto
+++ b/envoy/config/filter/network/tcp_proxy/v2/tcp_proxy.proto
@@ -35,7 +35,6 @@ message TcpProxy {
   //
   string cluster = 2;
 
-  // [#not-implemented-hide:]
   // Optional endpoint metadata match criteria. Only endpoints in the upstream
   // cluster with metadata matching that set in metadata_match will be
   // considered. The filter name should be specified as *envoy.lb*.


### PR DESCRIPTION
This got implemented here https://github.com/envoyproxy/envoy/pull/2708

Signed-off-by: Snow Pettersen <snowp@squareup.com>