### PR TITLE
change the oneof naming of fault delay

### DIFF
--- a/envoy/config/filter/fault/v2/fault.proto
+++ b/envoy/config/filter/fault/v2/fault.proto
@@ -26,7 +26,7 @@ message FaultDelay {
   // on which the delay will be injected.
   uint32 percent = 2 [(validate.rules).uint32.lte = 100];
 
-  oneof fault_delay_type {
+  oneof fault_delay_secifier {
     option (validate.required) = true;
     // Add a fixed delay before forwarding the operation upstream. See
     // https://developers.google.com/protocol-buffers/docs/proto3#json for


### PR DESCRIPTION
I am working on a scala data plane, which I got a code generation error as the `oneof` named `fault_delay_type` will result in the same name with the enum `FaultDelayType`.

```
envoy/config/filter/http/ip_tagging/v2/ip_tagging.proto: warning: Import google/protobuf/wrappers.proto but not used.
--scala_out: envoy/config/filter/fault/v2/fault.proto: The sealed trait generated for the oneof 'fault_delay_type' conflicts with another message name 'FaultDelayType'.
[trace] Stack trace suppressed: run last data-plane/compile:protocGenerate for the full output.
[error] (data-plane/compile:protocGenerate) protoc returned exit code: 1
[error] Total time: 1 s, completed Mar 15, 2018 6:12:40 PM
```

Although this is valid in protobuf and looks a bug of scala protobuf, I think I still want a fix here. Because as I look around, most of the fields are using pattern `*_specifer`.

I think this is not a breaking change in protobuf (but maybe break some languages implementation).

Correct me if I am wrong, thank you so much!