### PR TITLE
Enable no-traffic-interval of health check config

### DIFF
--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -5,7 +5,8 @@ Version history
 =====
 * http : added idle timeout for :ref:`upstream http connections
   <envoy_api_field_core.HttpProtocolOptions.idle_timeout>`.
-
+* health check: added setting for :ref:`no-traffic
+  interval<envoy_api_field_core.HealthCheck.no_traffic_interval>`.
 
 1.5.0
 =====

--- a/envoy/api/v2/core/health_check.proto
+++ b/envoy/api/v2/core/health_check.proto
@@ -125,11 +125,11 @@ message HealthCheck {
     GrpcHealthCheck grpc_health_check = 11;
   }
 
-  // [#not-implemented-hide:] The "no traffic interval" is a special health check interval that is
-  // used when a cluster has never had traffic routed to it. This lower interval allows cluster
-  // information to be kept up to date, without sending a potentially large amount of active health
-  // checking traffic for no reason. Once a cluster has been used for traffic routing, Envoy will
-  // shift back to using the standard health check interval that is defined.
+  // The "no traffic interval" is a special health check interval that is used when a cluster has
+  // never had traffic routed to it. This lower interval allows cluster information to be kept up to
+  // date, without sending a potentially large amount of active health checking traffic for no
+  // reason. Once a cluster has been used for traffic routing, Envoy will shift back to using the
+  // standard health check interval that is defined.
   //
   // The default value for "no traffic interval" is 60 seconds.
   google.protobuf.Duration no_traffic_interval = 12;


### PR DESCRIPTION
This enables the "no-traffic-interval" as supported by https://github.com/envoyproxy/envoy/pull/2835

Signed-off-by: Dhi Aurrahman <dio@rockybars.com>