### PR TITLE
docs: release note and docs for /config_dump admin endpoint

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -38,7 +38,10 @@ release_level = os.environ['ENVOY_DOCS_RELEASE_LEVEL']
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = ['sphinxcontrib.httpdomain', 'sphinx.ext.extlinks', 'sphinx.ext.ifconfig']
-extlinks = {'repo': ('https://github.com/envoyproxy/envoy/blob/master/%s', '')}
+extlinks = {
+  'repo': ('https://github.com/envoyproxy/envoy/blob/master/%s', ''),
+  'api': ('https://github.com/envoyproxy/data-plane-api/blob/master/%s', ''),
+}
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -3,10 +3,13 @@ Version history
 
 1.7.0
 =====
+
 * Added :ref:`weighted round robin
   <arch_overview_load_balancing_types_round_robin>` support. The round robin
   scheduler now respects endpoint weights and also has improved fidelity across
   picks.
+* admin: added :ref:`/config_dump endpoint <operations_admin_interface_config_dump>` for dumping current configs
+* admin: removed `/routes` endpoint; route configs can now be found at the :ref:`/config_dump endpoint <operations_admin_interface_config_dump>`.
 
 1.6.0
 =====
@@ -201,7 +204,7 @@ Version history
 * macOS is :repo:`now supported </bazel#quick-start-bazel-build-for-developers>`. (A few features
   are missing such as hot restart and original destination routing).
 * YAML is now directly supported for :ref:`config files <config_overview_v1>`.
-* Added :ref:`/routes <operations_admin_interface_routes>` admin endpoint.
+* Added /routes admin endpoint.
 * End-to-end flow control is now supported for TCP proxy, HTTP/1, and HTTP/2. HTTP flow control
   that includes filter buffering is incomplete and will be implemented in 1.5.0.
 * Log verbosity :repo:`compile time flag </bazel#log-verbosity>` added.

--- a/docs/root/operations/admin.rst
+++ b/docs/root/operations/admin.rst
@@ -103,6 +103,15 @@ modify different aspects of the server:
 
     */failed_outlier_check*: The host has failed an outlier detection check.
 
+.. _operations_admin_interface_config_dump:
+
+.. http:get:: /config_dump
+
+  Dump currently loaded configuration from various Envoy components as JSON-serialized proto
+  messages. Currently, only route configs are available but more are on the way. See
+  envoy/admin/v2/config_dump.proto for more information.  That proto is in draft state and is
+  subject to change.
+
 .. http:get:: /cpuprofiler
 
   Enable or disable the CPU profiler. Requires compiling with gperftools.
@@ -141,14 +150,6 @@ modify different aspects of the server:
   Reset all counters to zero. This is useful along with :http:get:`/stats` during debugging. Note
   that this does not drop any data sent to statsd. It just effects local output of the
   :http:get:`/stats` command.
-
-.. _operations_admin_interface_routes:
-
-.. http:get:: /routes?route_config_name=<name>
-
-  This endpoint is only available if envoy has HTTP routes configured via RDS.
-  The endpoint dumps all the configured HTTP route tables, or only ones that
-  match the ``route_config_name`` query, if a query is specified.
 
 .. http:get:: /server_info
 

--- a/docs/root/operations/admin.rst
+++ b/docs/root/operations/admin.rst
@@ -109,7 +109,7 @@ modify different aspects of the server:
 
   Dump currently loaded configuration from various Envoy components as JSON-serialized proto
   messages. Currently, only route configs are available but more are on the way. See
-  envoy/admin/v2/config_dump.proto for more information.  That proto is in draft state and is
+  envoy/admin/v2/config_dump.proto for more information. That proto is in draft state and is
   subject to change.
 
 .. http:get:: /cpuprofiler

--- a/docs/root/operations/admin.rst
+++ b/docs/root/operations/admin.rst
@@ -109,7 +109,7 @@ modify different aspects of the server:
 
   Dump currently loaded configuration from various Envoy components as JSON-serialized proto
   messages. Currently, only route configs are available but more are on the way. See
-  envoy/admin/v2/config_dump.proto for more information. That proto is in draft state and is
+  :api:`envoy/admin/v2/config_dump.proto` for more information. That proto is in draft state and is
   subject to change.
 
 .. http:get:: /cpuprofiler


### PR DESCRIPTION
The endpoint docs could use a link to `config_dump.proto` docs but we're not going to worry about generating those quite yet. Probably after a couple more endpoints are converted.

Test plan: `./docs/build.sh`

Signed-off-by: James Sedgwick <jsedgwick@lyft.com>