### PR TITLE
Fix broken grpc wire format link in http bridge doc.

### DIFF
--- a/docs/root/configuration/http_filters/grpc_http1_bridge_filter.rst
+++ b/docs/root/configuration/http_filters/grpc_http1_bridge_filter.rst
@@ -31,10 +31,10 @@ response trailers to a compliant gRPC server. It works by doing the following:
 * Because this scheme must buffer the response to look for the *grpc-status* trailer it will only
   work with unary gRPC APIs.
 
-More info: http://www.grpc.io/docs/guides/wire.html
-
 This filter also collects stats for all gRPC requests that transit, even if those requests are
 normal gRPC requests over HTTP/2.
+
+More info: wire format in `gRPC over HTTP/2 <https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md>`_.
 
 Statistics
 ----------


### PR DESCRIPTION
Due to there's actually no `HTTP/1.1` with gRPC format link. To avoid misunderstanding, I've adjusted the sequence and placed the **similar** wire format in gRPC over HTTP/2. The updated link is equivalent to wire format link in gRPC guide.

Ref to #555.

Signed-off-by: Tzu-Chiao Yeh <su3g4284zo6y7@gmail.com>