### PR TITLE
gRPC/JSON transcoder: enable preserving route after headers modified

### DIFF
--- a/envoy/config/filter/http/transcoder/v2/transcoder.proto
+++ b/envoy/config/filter/http/transcoder/v2/transcoder.proto
@@ -55,4 +55,9 @@ message GrpcJsonTranscoder {
   // `JsonPrintOptions <https://developers.google.com/protocol-buffers/docs/reference/cpp/
   // google.protobuf.util.json_util#JsonPrintOptions>`_.
   PrintOptions print_options = 3;
+
+  // Whether to keep the incoming request route after the outgoing headers have been transformed to
+  // the match the upstream gRPC service. Note: This means that routes for gRPC services that are
+  // not transcoded cannot be used in combination with *match_incoming_request_route*.
+  bool match_incoming_request_route = 5;
 }


### PR DESCRIPTION
the purpose of this PR is to add an option to the JSON-gRPC transcoder filter to allow preserving the original routing decision made by Envoy before this filter is called. Sometimes it is not desired that Envoy will not recalculate the route for a transcoded request; this option makes available that use case for the user.
Discussion can be found here: https://github.com/envoyproxy/envoy/issues/2847