### PR TITLE
docs: enable preserving route in gRPC transcoder after headers modified

### DIFF
--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -6,6 +6,8 @@ Version history
 
 * http : added idle timeout for :ref:`upstream http connections
   <envoy_api_field_core.HttpProtocolOptions.idle_timeout>`.
+* gRPC/JSON transcoder :ref:`filter <config_http_filters_grpc_json_transcoder>`: added option to disable recalculating
+  routes based on the modified request headers.
 * health check: added setting for :ref:`no-traffic
   interval<envoy_api_field_core.HealthCheck.no_traffic_interval>`.
 * tracing: when using the zipkin tracer, it is now possible for clients to specify the sampling decision (using

--- a/envoy/config/filter/http/transcoder/v2/transcoder.proto
+++ b/envoy/config/filter/http/transcoder/v2/transcoder.proto
@@ -55,4 +55,12 @@ message GrpcJsonTranscoder {
   // `JsonPrintOptions <https://developers.google.com/protocol-buffers/docs/reference/cpp/
   // google.protobuf.util.json_util#JsonPrintOptions>`_.
   PrintOptions print_options = 3;
+
+
+  // Whether to skip recalculating the route after the
+  // outgoing headers have been transformed to the match the upstream gRPC service
+  // If set to true, Envoy will determine the cluster to
+  // route to based on the route for the incoming request
+  // Defaults to false.
+  bool skip_recalculating_route = 5;
 }


### PR DESCRIPTION
Adds a release note for the following change: https://github.com/envoyproxy/data-plane-api/pull/569