### PR TITLE
Revert "lds: Make listen socket options optional and improve docs (#5…

### DIFF
--- a/docs/root/configuration/listener_filters/original_dst_filter.rst
+++ b/docs/root/configuration/listener_filters/original_dst_filter.rst
@@ -4,11 +4,10 @@ Original Destination
 ====================
 
 Original destination listener filter reads the SO_ORIGINAL_DST socket option set when a connection
-has been redirected by an iptables REDIRECT target, by or an iptables TPROXY target in combination
-with setting the listener's :ref:`transparent <envoy_api_field_Listener.transparent>` option.
-Later processing in Envoy sees the restored destination address as the connection's local address,
-rather than the address at which the listener is listening at. Furthermore, :ref:`an original
-destination cluster <arch_overview_service_discovery_types_original_destination>` may be used to
-forward HTTP requests or TCP connections to the restored destination address.
+has been redirected by iptables REDIRECT. Later processing in Envoy sees the restored destination
+address as the connection's local address, rather than the address at which the listener is
+listening at. Furthermore, :ref:`an original destination cluster
+<arch_overview_service_discovery_types_original_destination>` may be used to forward HTTP requests
+or TCP connections to the restored destination address.
 
 * :ref:`v2 API reference <envoy_api_field_listener.Filter.name>`

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -58,7 +58,6 @@ Version history
   <envoy_api_field_core.Address.pipe>`.
 * listeners: added support for :ref:`abstract unix domain sockets <envoy_api_msg_core.Pipe>` on
   Linux. The abstract namespace can be used by prepending '@' to a socket path.
-* listeners: added :ref:`transparent <envoy_api_field_Listener.transparent>` option.
 * load balancer: added cluster configuration for :ref:`healthy panic threshold
   <envoy_api_field_Cluster.CommonLbConfig.healthy_panic_threshold>` percentage.
 * load balancer: added :ref:`Maglev <arch_overview_load_balancing_types_maglev>` consistent hash

--- a/envoy/api/v2/lds.proto
+++ b/envoy/api/v2/lds.proto
@@ -127,27 +127,15 @@ message Listener {
   // before a connection is created.
   repeated listener.ListenerFilter listener_filters = 9 [(gogoproto.nullable) = false];
 
-  // Whether the listener should be set as a transparent socket.
-  // When this flag is set to true, connections can be redirected to the listener using an
-  // *iptables* *TPROXY* target, in which case the original source and destination addresses and
-  // ports are preserved on accepted connections. This flag should be used in combination with
-  // :ref:`an original_dst <config_listener_filters_original_dst>` :ref:`listener filter
-  // <envoy_api_field_Listener.listener_filters>` to mark the connections' local addresses as
-  // "restored." This can be used to hand off each redirected connection to another listener
-  // associated with the connection's destination address. Direct connections to the socket without
-  // using *TPROXY* cannot be distinguished from connections redirected using *TPROXY* and are
-  // therefore treated as if they were redirected.
-  // When this flag is set to false, the listener's socket is explicitly reset as non-transparent.
-  // Setting this flag requires Envoy to run with the *CAP_NET_ADMIN* capability.
-  // When this flag is not set (default), the socket is not modified, i.e. the transparent option
-  // is neither set nor reset.
-  google.protobuf.BoolValue transparent = 10;
+  // [#not-implemented-hide:]
+  // Whether the listener should be set as a transparent socket. When this flag is set to true,
+  // connections can be redirected to the listener using an *iptables* *TPROXY* target, in which
+  // case the original source and destination addresses and ports are preserved on accepted
+  // connections. Requires Envoy to run with the *CAP_NET_ADMIN* capability. Defaults to false.
+  bool transparent = 10;
 
   // [#not-implemented-hide:] Whether the listener should set the IP_FREEBIND socket option. When
-  // this flag is set to true, listeners can be bound to an IP address that is not configured on
-  // the system running Envoy.
-  // When this flag is set to false, the option IP_FREEBIND is disabled on the socket.
-  // When this flag is not set (default), the socket is not modified, i.e. the option is neither
-  // enabled nor disabled.
-  google.protobuf.BoolValue freebind = 11;
+  // this flag is set to true listeners can be bound to an IP address that is not configured on the
+  // system running Envoy. Defaults to false.
+  bool freebind = 11;
 }

--- a/envoy/api/v2/lds.proto
+++ b/envoy/api/v2/lds.proto
@@ -128,14 +128,27 @@ message Listener {
   repeated listener.ListenerFilter listener_filters = 9 [(gogoproto.nullable) = false];
 
   // [#not-implemented-hide:]
-  // Whether the listener should be set as a transparent socket. When this flag is set to true,
-  // connections can be redirected to the listener using an *iptables* *TPROXY* target, in which
-  // case the original source and destination addresses and ports are preserved on accepted
-  // connections. Requires Envoy to run with the *CAP_NET_ADMIN* capability. Defaults to false.
+  // Whether the listener should be set as a transparent socket.
+  // When this flag is set to true, connections can be redirected to the listener using an
+  // *iptables* *TPROXY* target, in which case the original source and destination addresses and
+  // ports are preserved on accepted connections. This flag should be used in combination with
+  // :ref:`an original_dst <config_listener_filters_original_dst>` :ref:`listener filter
+  // <envoy_api_field_Listener.listener_filters>` to mark the connections' local addresses as
+  // "restored." This can be used to hand off each redirected connection to another listener
+  // associated with the connection's destination address. Direct connections to the socket without
+  // using *TPROXY* cannot be distinguished from connections redirected using *TPROXY* and are
+  // therefore treated as if they were redirected.
+  // When this flag is set to false, the listener's socket is explicitly reset as non-transparent.
+  // Setting this flag requires Envoy to run with the *CAP_NET_ADMIN* capability.
+  // When this flag is not set (default), the socket is not modified, i.e. the transparent option
+  // is neither set nor reset.
   google.protobuf.BoolValue transparent = 10;
 
   // [#not-implemented-hide:] Whether the listener should set the IP_FREEBIND socket option. When
-  // this flag is set to true listeners can be bound to an IP address that is not configured on the
-  // system running Envoy. Defaults to false.
+  // this flag is set to true, listeners can be bound to an IP address that is not configured on
+  // the system running Envoy.
+  // When this flag is set to false, the option IP_FREEBIND is disabled on the socket.
+  // When this flag is not set (default), the socket is not modified, i.e. the option is neither
+  // enabled nor disabled.
   google.protobuf.BoolValue freebind = 11;
 }

--- a/envoy/api/v2/lds.proto
+++ b/envoy/api/v2/lds.proto
@@ -132,10 +132,10 @@ message Listener {
   // connections can be redirected to the listener using an *iptables* *TPROXY* target, in which
   // case the original source and destination addresses and ports are preserved on accepted
   // connections. Requires Envoy to run with the *CAP_NET_ADMIN* capability. Defaults to false.
-  bool transparent = 10;
+  google.protobuf.BoolValue transparent = 10;
 
   // [#not-implemented-hide:] Whether the listener should set the IP_FREEBIND socket option. When
   // this flag is set to true listeners can be bound to an IP address that is not configured on the
   // system running Envoy. Defaults to false.
-  bool freebind = 11;
+  google.protobuf.BoolValue freebind = 11;
 }


### PR DESCRIPTION
This reverts commit 24c90e9c9a12b6224fc872f0a15b4b35cc478165.

This is not going to make the 1.6.0 cut. Will need to be reapplied for 1.7.0. https://github.com/envoyproxy/data-plane-api/pull/558. @rlenglet 

