### PR TITLE
docs: add /stats/prometheus as an alternative endpoint

### DIFF
--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -7,6 +7,7 @@ Version history
   <arch_overview_load_balancing_types_round_robin>` support. The round robin
   scheduler now respects endpoint weights and also has improved fidelity across
   picks.
+* admin: added ``/stats/prometheus`` as an alternative endpoint for getting stats in prometheus format.
 
 1.6.0
 =====

--- a/docs/root/operations/admin.rst
+++ b/docs/root/operations/admin.rst
@@ -182,6 +182,10 @@ The fields are:
 
   .. http:get:: /stats?format=prometheus
 
+  or alternatively,
+
+  .. http:get:: /stats/prometheus
+
   Outputs /stats in `Prometheus <https://prometheus.io/docs/instrumenting/exposition_formats/>`_
   v0.0.4 format. This can be used to integrate with a Prometheus server. Currently, only counters and
   gauges are output. Histograms will be output in a future update.


### PR DESCRIPTION
This patch adds info of /stats/prometheus as an alternative endpoint to
get server stats in prometheus format.

Refs: 
- https://github.com/envoyproxy/envoy/issues/2182
- https://github.com/envoyproxy/envoy/pull/2896

Signed-off-by: Dhi Aurrahman <dio@rockybars.com>