### PR TITLE
BindConfig: make upstream and downstream bind config consistent.

### DIFF
--- a/envoy/api/v2/core/address.proto
+++ b/envoy/api/v2/core/address.proto
@@ -63,10 +63,14 @@ message BindConfig {
   SocketAddress source_address = 1
       [(validate.rules).message.required = true, (gogoproto.nullable) = false];
 
-  // [#not-implemented-hide:] Whether to set the IP_FREEBIND option when creating the socket. If
-  // set, allows the source_address specified to be an address that is not configured on the system
-  // running Envoy. Defaults to false.
-  bool freebind = 2;
+  // [#not-implemented-hide:] Whether to set the *IP_FREEBIND* option when
+  // creating the socket. When this flag is set to true, allows the
+  // :ref:`source_address <envoy_api_field_UpstreamBindConfig.source_address>`
+  // to be an IP address that is not configured on the system running Envoy.
+  // When this flag is set to false, the option *IP_FREEBIND* is disabled on the
+  // socket. When this flag is not set (default), the socket is not modified,
+  // i.e. the option is neither enabled nor disabled.
+  google.protobuf.BoolValue freebind = 2;
 }
 
 // Addresses specify either a logical or physical address and port, which are

--- a/envoy/api/v2/lds.proto
+++ b/envoy/api/v2/lds.proto
@@ -144,11 +144,11 @@ message Listener {
   // is neither set nor reset.
   google.protobuf.BoolValue transparent = 10;
 
-  // [#not-implemented-hide:] Whether the listener should set the IP_FREEBIND socket option. When
-  // this flag is set to true, listeners can be bound to an IP address that is not configured on
-  // the system running Envoy.
-  // When this flag is set to false, the option IP_FREEBIND is disabled on the socket.
-  // When this flag is not set (default), the socket is not modified, i.e. the option is neither
-  // enabled nor disabled.
+  // [#not-implemented-hide:] Whether the listener should set the *IP_FREEBIND*
+  // socket option. When this flag is set to true, listeners can be bound to an
+  // IP address that is not configured on the system running Envoy. When this
+  // flag is set to false, the option *IP_FREEBIND* is disabled on the socket.
+  // When this flag is not set (default), the socket is not modified, i.e. the
+  // option is neither enabled nor disabled.
   google.protobuf.BoolValue freebind = 11;
 }


### PR DESCRIPTION
This follows up from #558 which made IP_FREEBIND a BoolValue for LDS but
not for upstream. I think it makes sense to have it in both places given
the new socket options setup introduce in
https://github.com/envoyproxy/envoy/pull/2734.

Some bonus docs fixups thrown in.

Signed-off-by: Harvey Tuch <htuch@google.com>