### PR TITLE
Add `api_go_proto_library` targets for HTTP connection manager protos.

### DIFF
--- a/envoy/config/filter/accesslog/v2/BUILD
+++ b/envoy/config/filter/accesslog/v2/BUILD
@@ -1,4 +1,4 @@
-load("//bazel:api_build_system.bzl", "api_proto_library")
+load("//bazel:api_build_system.bzl", "api_proto_library", "api_go_proto_library")
 
 licenses(["notice"])  # Apache 2
 
@@ -16,5 +16,22 @@ api_proto_library(
         "//envoy/api/v2/core:base",
         "//envoy/api/v2/core:grpc_service",
         "//envoy/type:percent",
+    ],
+)
+
+api_go_proto_library(
+    name = "accesslog",
+    proto = ":accesslog",
+    visibility = [
+        "//envoy/config/filter/http/router/v2:__pkg__",
+        "//envoy/config/filter/network/http_connection_manager/v2:__pkg__",
+        "//envoy/config/filter/network/tcp_proxy/v2:__pkg__",
+        "//envoy/service/accesslog/v2:__pkg__",
+    ],
+    deps = [
+        "//envoy/api/v2/core:address_go_proto",
+        "//envoy/api/v2/core:base_go_proto",
+        "//envoy/api/v2/core:grpc_service_go_proto",
+        "//envoy/type:percent_go_proto",
     ],
 )

--- a/envoy/config/filter/accesslog/v2/BUILD
+++ b/envoy/config/filter/accesslog/v2/BUILD
@@ -22,12 +22,6 @@ api_proto_library(
 api_go_proto_library(
     name = "accesslog",
     proto = ":accesslog",
-    visibility = [
-        "//envoy/config/filter/http/router/v2:__pkg__",
-        "//envoy/config/filter/network/http_connection_manager/v2:__pkg__",
-        "//envoy/config/filter/network/tcp_proxy/v2:__pkg__",
-        "//envoy/service/accesslog/v2:__pkg__",
-    ],
     deps = [
         "//envoy/api/v2/core:address_go_proto",
         "//envoy/api/v2/core:base_go_proto",

--- a/envoy/config/filter/network/http_connection_manager/v2/BUILD
+++ b/envoy/config/filter/network/http_connection_manager/v2/BUILD
@@ -1,4 +1,4 @@
-load("//bazel:api_build_system.bzl", "api_proto_library")
+load("//bazel:api_build_system.bzl", "api_proto_library", "api_go_proto_library")
 
 licenses(["notice"])  # Apache 2
 
@@ -12,5 +12,18 @@ api_proto_library(
         "//envoy/api/v2/core:protocol",
         "//envoy/config/filter/accesslog/v2:accesslog",
         "//envoy/type:percent",
+    ],
+)
+
+api_go_proto_library(
+    name = "http_connection_manager",
+    proto = ":http_connection_manager",
+    deps = [
+        "//envoy/api/v2:rds_go_grpc",
+        "//envoy/api/v2/core:base_go_proto",
+        "//envoy/api/v2/core:config_source_go_proto",
+        "//envoy/api/v2/core:protocol_go_proto",
+        "//envoy/config/filter/accesslog/v2:accesslog_go_proto",
+        "//envoy/type:percent_go_proto",
     ],
 )


### PR DESCRIPTION
These are required to generate xDS responses from a Go binary. If they
don't exist, implementations are required to vendor the data-plane-api
with this change applied.

Signed-off-by: John Millikin <jmillikin@stripe.com>

cc @kshia