### PR TITLE
health check: support sending additional headers

### DIFF
--- a/envoy/api/v2/core/health_check.proto
+++ b/envoy/api/v2/core/health_check.proto
@@ -2,6 +2,8 @@ syntax = "proto3";
 
 package envoy.api.v2.core;
 
+import "envoy/api/v2/core/base.proto";
+
 import "google/protobuf/duration.proto";
 import "google/protobuf/wrappers.proto";
 
@@ -76,6 +78,11 @@ message HealthCheck {
     // the health checked cluster. See the :ref:`architecture overview
     // <arch_overview_health_checking_identity>` for more information.
     string service_name = 5;
+
+    // [#not-implemented-hide:]
+    // Specifies a list of HTTP headers that should be added to each request that is sent
+    // to the health checked cluster.
+    repeated core.HeaderValueOption request_headers_to_add = 6;
   }
 
   message TcpHealthCheck {


### PR DESCRIPTION
This supports sending additional HTTP headers for each request
that is sent to the health checked cluster. 

Ref: https://github.com/envoyproxy/envoy/issues/2888

Signed-off-by: Dhi Aurrahman <dio@rockybars.com>