### PR TITLE
Build: Add explicit python version to virtualenv in /docs/build.sh

### DIFF
--- a/docs/build.sh
+++ b/docs/build.sh
@@ -14,7 +14,7 @@ rm -rf "${GENERATED_RST_DIR}"
 mkdir -p "${GENERATED_RST_DIR}"
 
 if [ ! -d "${BUILD_DIR}"/venv ]; then
-  virtualenv "${BUILD_DIR}"/venv --no-site-packages
+  virtualenv "${BUILD_DIR}"/venv --no-site-packages --python=python2.7
   "${BUILD_DIR}"/venv/bin/pip install -r "${SCRIPT_DIR}"/requirements.txt
 fi
 


### PR DESCRIPTION
The current build.sh file will attempt to use the default python version (in my case 3.6) instead of python2.7 which seems to be the required version due to the standard library having removed StringIO from python3.

Signed-off-by: Nicholas Johns <nicholas.a.johns5@gmail.com>