### PR TITLE
mongo-proxy: support for OP_COMMAND and OP_COMMANDREPLY

### DIFF
--- a/docs/root/configuration/network_filters/mongo_proxy_filter.rst
+++ b/docs/root/configuration/network_filters/mongo_proxy_filter.rst
@@ -37,6 +37,8 @@ following statistics:
   op_query_no_cursor_timeout, Counter, Number of OP_QUERY with no cursor timeout flag set
   op_query_await_data, Counter, Number of OP_QUERY with await data flag set
   op_query_exhaust, Counter, Number of OP_QUERY with exhaust flag set
+  op_command, Counter, Number of OP_COMMAND messages
+  op_command_reply, Counter, Number of OP_COMMANDREPLY messages
   op_query_no_max_time, Counter, Number of queries without maxTimeMS set
   op_query_scatter_get, Counter, Number of scatter get queries
   op_query_multi_get, Counter, Number of multi get queries

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -27,6 +27,9 @@ Version history
 * tracing: the sampling decision is now delegated to the tracers, allowing the tracer to decide when and if
   to use it. For example, if the :ref:`x-b3-sampled <config_http_conn_man_headers_x-b3-sampled>` header
   is supplied with the client request, its value will override any sampling decision made by the Envoy proxy.
+* mongo-proxy: added parsing support for OP_COMMAND and OP_COMMANDREPLY messages.
+  :ref:`Mongo proxy Statistics <config_network_filters_mongo_proxy_stats>` keep track of number of OP_COMMAND
+  and OP_COMMANDREPLY messages.
 
 1.6.0
 =====


### PR DESCRIPTION
Description: documentation changes addressing issue #2745 and PR #2945.

- updated release notes for 1.7.0
- updated documentation with new counters for OP_COMMAND and OP_COMMANDREPLY messages