### PR TITLE
docs: unhide request headers to add field for health check

### DIFF
--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -15,7 +15,7 @@ Version history
 * cli: added --config-yaml flag to the Envoy binary. When set its value is interpreted as a yaml
   representation of the bootstrap config and overrides --config-path.
 * health check: added ability to set :ref:`additional HTTP headers
-  <envoy_api_field_core.HealthCheck.HttpHealthCheck.request_headers_to_add>` for http health check.
+  <envoy_api_field_core.HealthCheck.HttpHealthCheck.request_headers_to_add>` for HTTP health check.
 * logger: all :ref:`logging levels <operations_admin_interface_logging>` can be configured
   at run-time: trace debug info warning error critical.
 * logger: added the ability to optionally set the log format via the :option:`--log-format` option.

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -14,6 +14,8 @@ Version history
 * admin: added ``/stats/prometheus`` as an alternative endpoint for getting stats in prometheus format.
 * cli: added --config-yaml flag to the Envoy binary. When set its value is interpreted as a yaml
   representation of the bootstrap config and overrides --config-path.
+* health check: added ability to set :ref:`additional HTTP headers
+  <envoy_api_field_core.HealthCheck.HttpHealthCheck.request_headers_to_add>` for http health check.
 * logger: all :ref:`logging levels <operations_admin_interface_logging>` can be configured
   at run-time: trace debug info warning error critical.
 * logger: added the ability to optionally set the log format via the :option:`--log-format` option.

--- a/envoy/api/v2/core/health_check.proto
+++ b/envoy/api/v2/core/health_check.proto
@@ -79,9 +79,8 @@ message HealthCheck {
     // <arch_overview_health_checking_identity>` for more information.
     string service_name = 5;
 
-    // [#not-implemented-hide:]
-    // Specifies a list of HTTP headers that should be added to each request that is sent
-    // to the health checked cluster.
+    // Specifies a list of HTTP headers that should be added to each request that is sent to the
+    // health checked cluster.
     repeated core.HeaderValueOption request_headers_to_add = 6;
   }
 


### PR DESCRIPTION
This unhides request-headers-to-add field for HTTP health check and put a
release note line in the version history.

Signed-off-by: Dhi Aurrahman <dio@rockybars.com>