### PR TITLE
Add extension health checker

### DIFF
--- a/docs/BUILD
+++ b/docs/BUILD
@@ -43,6 +43,7 @@ proto_library(
         "//envoy/config/filter/network/rate_limit/v2:rate_limit",
         "//envoy/config/filter/network/redis_proxy/v2:redis_proxy",
         "//envoy/config/filter/network/tcp_proxy/v2:tcp_proxy",
+        "//envoy/config/health_checker/redis/v2:redis",
         "//envoy/config/metrics/v2:metrics_service",
         "//envoy/config/metrics/v2:stats",
         "//envoy/config/ratelimit/v2:rls",

--- a/envoy/api/v2/core/health_check.proto
+++ b/envoy/api/v2/core/health_check.proto
@@ -5,6 +5,7 @@ package envoy.api.v2.core;
 import "envoy/api/v2/core/base.proto";
 
 import "google/protobuf/duration.proto";
+import "google/protobuf/struct.proto";
 import "google/protobuf/wrappers.proto";
 
 import "validate/validate.proto";
@@ -116,6 +117,16 @@ message HealthCheck {
     string service_name = 1;
   }
 
+  // [#not-implemented-hide:] Custom health check.
+  message ExtensionHealthCheck {
+    // The registered name of the extension health check.
+    string name = 1 [(validate.rules).string.min_bytes = 1];
+
+    // An extension health checker specific configuration which depends on the extension health
+    // checker being instantiated.
+    google.protobuf.Struct config = 2;
+  }
+
   oneof health_checker {
     option (validate.required) = true;
 
@@ -130,6 +141,9 @@ message HealthCheck {
 
     // gRPC health check.
     GrpcHealthCheck grpc_health_check = 11;
+
+    // [#not-implemented-hide:] Extension health check.
+    ExtensionHealthCheck extension_health_check = 12;
   }
 
   // The "no traffic interval" is a special health check interval that is used when a cluster has
@@ -139,7 +153,7 @@ message HealthCheck {
   // standard health check interval that is defined.
   //
   // The default value for "no traffic interval" is 60 seconds.
-  google.protobuf.Duration no_traffic_interval = 12;
+  google.protobuf.Duration no_traffic_interval = 13;
 }
 
 // [#not-implemented-hide:] Part of HDS.

--- a/envoy/config/health_checker/redis/v2/BUILD
+++ b/envoy/config/health_checker/redis/v2/BUILD
@@ -1,0 +1,8 @@
+load("//bazel:api_build_system.bzl", "api_proto_library")
+
+licenses(["notice"])  # Apache 2
+
+api_proto_library(
+    name = "redis",
+    srcs = ["redis.proto"],
+)

--- a/envoy/config/health_checker/redis/v2/redis.proto
+++ b/envoy/config/health_checker/redis/v2/redis.proto
@@ -1,0 +1,16 @@
+syntax = "proto3";
+
+package envoy.config.health_checker.redis.v2;
+option go_package = "v2";
+
+// [#not-implemented-hide:]
+// [#protodoc-title: Redis]
+// Redis :ref:`configuration overview <config_health_checker_redis>`.
+// Configuration for the redis extension health checker.
+message Redis {
+  // If set, optionally perform ``EXISTS <key>`` instead of ``PING``. A return value
+  // from Redis of 0 (does not exist) is considered a passing healthcheck. A return value other
+  // than 0 is considered a failure. This allows the user to mark a Redis instance for maintenance
+  // by setting the specified key to any value and waiting for traffic to drain.
+  string key = 1;
+}

--- a/test/validate/BUILD
+++ b/test/validate/BUILD
@@ -28,5 +28,6 @@ api_cc_test(
         "//envoy/config/filter/network/mongo_proxy/v2:mongo_proxy",
         "//envoy/config/filter/network/redis_proxy/v2:redis_proxy",
         "//envoy/config/filter/network/tcp_proxy/v2:tcp_proxy",
+        "//envoy/config/health_checker/redis/v2:redis",
     ],
 )

--- a/test/validate/pgv_test.cc
+++ b/test/validate/pgv_test.cc
@@ -8,6 +8,7 @@
 #include "envoy/api/v2/lds.pb.validate.h"
 #include "envoy/api/v2/rds.pb.validate.h"
 #include "envoy/api/v2/core/protocol.pb.validate.h"
+#include "envoy/config/health_checker/redis/v2/redis.pb.validate.h"
 #include "envoy/config/filter/accesslog/v2/accesslog.pb.validate.h"
 #include "envoy/config/filter/http/buffer/v2/buffer.pb.validate.h"
 #include "envoy/config/filter/http/fault/v2/fault.pb.validate.h"


### PR DESCRIPTION
This patch adds the extension health checker, with redis as the first example.

Ref: https://github.com/envoyproxy/envoy/issues/2933

Signed-off-by: Dhi Aurrahman <dio@rockybars.com>