### PR TITLE
health check: add optional alternative health check port

### DIFF
--- a/envoy/api/v2/endpoint/endpoint.proto
+++ b/envoy/api/v2/endpoint/endpoint.proto
@@ -23,13 +23,13 @@ message Endpoint {
 
   // [#not-implemented-hide:] The optional health check configuration.
   message HealthCheckConfig {
-    // Optional alternative health check port.
+    // Optional alternative health check port value.
     //
     // By default the health check address port of an upstream host is the same
     // as the host's serving address port. This provides an alternative health
     // check port. If set it allows an upstream host to have different
     // health check address port.
-    uint32 health_check_port = 1;
+    uint32 port_value = 1;
   }
 
   // [#not-implemented-hide:] The optional health check configuration is used as

--- a/envoy/api/v2/endpoint/endpoint.proto
+++ b/envoy/api/v2/endpoint/endpoint.proto
@@ -35,7 +35,7 @@ message Endpoint {
     // as the host's serving address port. This provides an alternative health
     // check port. If set it allows an upstream host to have different
     // health check address port.
-    uint32 health_check_port = 2;
+    uint32 health_check_port = 1;
   }
 }
 

--- a/envoy/api/v2/endpoint/endpoint.proto
+++ b/envoy/api/v2/endpoint/endpoint.proto
@@ -21,12 +21,22 @@ message Endpoint {
   // The upstream host address.
   core.Address address = 1;
 
-  // [#not-implemented-hide:] Optional alternative health check port.
+  // [#not-implemented-hide:] The optional health check configuration is used as
+  // configuration for the health checker to contact the health checked host.
   //
-  // By default the health check address port of an upstream host is the same as the host's serving
-  // address port. This provides an alternative health check port. If set it allows an upstream host
-  // to have different health check address port.
-  uint32 health_check_port = 2;
+  // .. attention::
+  //
+  //    This takes into effect only for upstream clusters with
+  //    :ref:`active health checking <arch_overview_health_checking>` enabled.
+  message HealthCheckConfig {
+    // Optional alternative health check port.
+    //
+    // By default the health check address port of an upstream host is the same
+    // as the host's serving address port. This provides an alternative health
+    // check port. If set it allows an upstream host to have different
+    // health check address port.
+    uint32 health_check_port = 2;
+  }
 }
 
 // An Endpoint that Envoy can route traffic to.

--- a/envoy/api/v2/endpoint/endpoint.proto
+++ b/envoy/api/v2/endpoint/endpoint.proto
@@ -21,13 +21,7 @@ message Endpoint {
   // The upstream host address.
   core.Address address = 1;
 
-  // [#not-implemented-hide:] The optional health check configuration is used as
-  // configuration for the health checker to contact the health checked host.
-  //
-  // .. attention::
-  //
-  //    This takes into effect only for upstream clusters with
-  //    :ref:`active health checking <arch_overview_health_checking>` enabled.
+  // [#not-implemented-hide:] The optional health check configuration.
   message HealthCheckConfig {
     // Optional alternative health check port.
     //
@@ -37,6 +31,15 @@ message Endpoint {
     // health check address port.
     uint32 health_check_port = 1;
   }
+
+  // [#not-implemented-hide:] The optional health check configuration is used as
+  // configuration for the health checker to contact the health checked host.
+  //
+  // .. attention::
+  //
+  //   This takes into effect only for upstream clusters with
+  //   :ref:`active health checking <arch_overview_health_checking>` enabled.
+  HealthCheckConfig health_check_config = 2;
 }
 
 // An Endpoint that Envoy can route traffic to.

--- a/envoy/api/v2/endpoint/endpoint.proto
+++ b/envoy/api/v2/endpoint/endpoint.proto
@@ -27,8 +27,8 @@ message Endpoint {
     //
     // By default the health check address port of an upstream host is the same
     // as the host's serving address port. This provides an alternative health
-    // check port. If set it allows an upstream host to have different
-    // health check address port.
+    // check port. Setting this with a non-zero value allows an upstream host
+    // to have different health check address port.
     uint32 port_value = 1;
   }
 

--- a/envoy/api/v2/endpoint/endpoint.proto
+++ b/envoy/api/v2/endpoint/endpoint.proto
@@ -25,7 +25,7 @@ message Endpoint {
   //
   // By default the health check address port of an upstream host is the same as the host's serving
   // address port. This provides an alternative health check port. If set it allows an upstream host
-  // to have different health check address port. The health checker should honor this.
+  // to have different health check address port.
   uint32 health_check_port = 2;
 }
 

--- a/envoy/api/v2/endpoint/endpoint.proto
+++ b/envoy/api/v2/endpoint/endpoint.proto
@@ -18,7 +18,15 @@ option (gogoproto.equal_all) = true;
 
 // Upstream host identifier.
 message Endpoint {
+  // The upstream host address.
   core.Address address = 1;
+
+  // [#not-implemented-hide:] Optional alternative health check port.
+  //
+  // By default the health check address port of an upstream host is the same as the host's serving
+  // address port. This provides an alternative health check port. If set it allows an upstream host
+  // to have different health check address port. The health checker should honor this.
+  uint32 health_check_port = 2;
 }
 
 // An Endpoint that Envoy can route traffic to.


### PR DESCRIPTION
This provides an alternative health check port, if set it allows an
upstream host to have different health check address port.

Ref: https://github.com/envoyproxy/envoy/issues/439

Signed-off-by: Dhi Aurrahman <dio@rockybars.com>