### PR TITLE
add cluster metadata to a route

### DIFF
--- a/envoy/api/v2/route/route.proto
+++ b/envoy/api/v2/route/route.proto
@@ -193,8 +193,9 @@ message WeightedCluster {
     // For instance, if the metadata is intended for the Router filter,
     // the filter name should be specified as *envoy.router*.
     //
-    // On runtime, this object will a merged with the cluster_metadata from the enclosing
-    // :ref:`envoy_api_msg_route.RouteAction`.
+    // On runtime, this object will a merged with the
+    // :ref:`cluster_metadata <envoy_api_field_route.RouteAction.cluster_metadata>` from the
+    // enclosing :ref:`envoy_api_msg_route.RouteAction`.
     core.Metadata cluster_metadata = 7;
   }
 

--- a/envoy/api/v2/route/route.proto
+++ b/envoy/api/v2/route/route.proto
@@ -186,6 +186,16 @@ message WeightedCluster {
     // Specifies a list of headers to be removed from responses when this cluster is selected
     // through the enclosing :ref:`envoy_api_msg_route.RouteAction`.
     repeated string response_headers_to_remove = 6;
+
+    // [#not-implemented-hide:] The Metadata field can be used to provide additional information
+    // about the cluster chosen for routing. It can be used for configuration, stats, and logging.
+    // The metadata should go under the filter namespace that will need it.
+    // For instance, if the metadata is intended for the Router filter,
+    // the filter name should be specified as *envoy.router*.
+    //
+    // On runtime, this object will a merged with the cluster_metadata from the enclosing
+    // :ref:`envoy_api_msg_route.RouteAction`.
+    core.Metadata cluster_metadata = 7;
   }
 
   // Specifies one or more upstream clusters associated with the route.
@@ -532,6 +542,13 @@ message RouteAction {
 
   // Indicates that the route has a CORS policy.
   CorsPolicy cors = 17;
+
+  // [#not-implemented-hide:] The Metadata field can be used to provide additional information
+  // about the routed cluster. It can be used for configuration, stats, and logging.
+  // The metadata should go under the filter namespace that will need it.
+  // For instance, if the metadata is intended for the Router filter,
+  // the filter name should be specified as *envoy.router*.
+  core.Metadata cluster_metadata = 21;
 }
 
 message RedirectAction {


### PR DESCRIPTION
Per https://github.com/envoyproxy/envoy/issues/2851, adding metadata object to the specific routed cluster. envoy patch is ready and a PR for envoy will be created when this PR is merged (so I can update the repository_locations.bzl)
