### PR TITLE
stats: add prefix to StatsConfig

### DIFF
--- a/envoy/config/metrics/v2/stats.proto
+++ b/envoy/config/metrics/v2/stats.proto
@@ -155,6 +155,7 @@ message StatsdSink {
     // Envoy will connect to this cluster to flush statistics.
     string tcp_cluster_name = 2;
   }
+  string prefix = 3;
 }
 
 // Stats configuration proto schema for built-in *envoy.dog_statsd* sink.


### PR DESCRIPTION
Add prefix field to StatsdSink proto definition to support custom prefixes. 
See envoyproxy/envoy#2897 for more details.

Signed-off-by: Akhil Thampy <akhil@akhilthampy.com>