### PR TITLE
stats:  add prefix to StatsConfig

### DIFF
--- a/envoy/config/metrics/v2/stats.proto
+++ b/envoy/config/metrics/v2/stats.proto
@@ -166,7 +166,7 @@ message StatsdSink {
   //   envoy-prod.test_timer:5|ms
   //
   // Note that the default prefix, "envoy", will be used if a prefix is not
-  // specified. 
+  // specified.
   // Stats with default prefix:
   // .. code-block:: cpp
   //   envoy.test_counter:1|c

--- a/envoy/config/metrics/v2/stats.proto
+++ b/envoy/config/metrics/v2/stats.proto
@@ -158,20 +158,29 @@ message StatsdSink {
   // [#not-implemented-hide:] Optional custom prefix for StatsdSink. If
   // specified, this will override the default prefix.
   // For example:
+  //
   // .. code-block:: json
-  //   prefix : "envoy-prod"
+  //
+  //   {
+  //     "prefix" : "envoy-prod"
+  //   }
+  //
   // will change emitted stats to
+  //
   // .. code-block:: cpp
+  //
   //   envoy-prod.test_counter:1|c
   //   envoy-prod.test_timer:5|ms
   //
   // Note that the default prefix, "envoy", will be used if a prefix is not
   // specified.
+  //
   // Stats with default prefix:
+  //
   // .. code-block:: cpp
+  //
   //   envoy.test_counter:1|c
   //   envoy.test_timer:5|ms
-
   string prefix = 3;
 }
 

--- a/envoy/config/metrics/v2/stats.proto
+++ b/envoy/config/metrics/v2/stats.proto
@@ -155,6 +155,7 @@ message StatsdSink {
     // Envoy will connect to this cluster to flush statistics.
     string tcp_cluster_name = 2;
   }
+  string prefix = 3;
 }
 
 // Stats configuration proto schema for built-in *envoy.dog_statsd* sink.

--- a/envoy/config/metrics/v2/stats.proto
+++ b/envoy/config/metrics/v2/stats.proto
@@ -164,6 +164,13 @@ message StatsdSink {
   // .. code-block:: cpp
   //   envoy-prod.test_counter:1|c
   //   envoy-prod.test_timer:5|ms
+  //
+  // Note that the default prefix, "envoy", will be used if a prefix is not
+  // specified. 
+  // Stats with default prefix:
+  // .. code-block:: cpp
+  //   envoy.test_counter:1|c
+  //   envoy.test_timer:5|ms
 
   string prefix = 3;
 }

--- a/envoy/config/metrics/v2/stats.proto
+++ b/envoy/config/metrics/v2/stats.proto
@@ -155,6 +155,8 @@ message StatsdSink {
     // Envoy will connect to this cluster to flush statistics.
     string tcp_cluster_name = 2;
   }
+  // [#not-implemented-hide:] Optional custom prefix for StatsdSink. If
+  // specified, this will override the default prefix.
   string prefix = 3;
 }
 

--- a/envoy/config/metrics/v2/stats.proto
+++ b/envoy/config/metrics/v2/stats.proto
@@ -157,6 +157,14 @@ message StatsdSink {
   }
   // [#not-implemented-hide:] Optional custom prefix for StatsdSink. If
   // specified, this will override the default prefix.
+  // For example:
+  // .. code-block:: json
+  //   prefix : "envoy-prod"
+  // will change emitted stats to
+  // .. code-block:: cpp
+  //   envoy-prod.test_counter:1|c
+  //   envoy-prod.test_timer:5|ms
+
   string prefix = 3;
 }
 


### PR DESCRIPTION
Add prefix field to StatsdSink proto definition to support custom prefixes.
See envoyproxy/envoy#2897 for more details.

Signed-off-by: Akhil Thampy <akhil@akhilthampy.com>