### PR TITLE
Unhide redis health check ext

### DIFF
--- a/docs/build.sh
+++ b/docs/build.sh
@@ -67,6 +67,7 @@ PROTO_RST="
   /envoy/config/filter/network/rate_limit/v2/rate_limit/envoy/config/filter/network/rate_limit/v2/rate_limit.proto.rst
   /envoy/config/filter/network/redis_proxy/v2/redis_proxy/envoy/config/filter/network/redis_proxy/v2/redis_proxy.proto.rst
   /envoy/config/filter/network/tcp_proxy/v2/tcp_proxy/envoy/config/filter/network/tcp_proxy/v2/tcp_proxy.proto.rst
+  /envoy/config/health_checker/redis/v2/redis/envoy/config/health_checker/redis/v2/redis.proto.rst
   /envoy/type/percent/envoy/type/percent.proto.rst
   /envoy/type/range/envoy/type/range.proto.rst
 "

--- a/docs/root/api-v2/api.rst
+++ b/docs/root/api-v2/api.rst
@@ -12,5 +12,6 @@ v2 API reference
   clusters/clusters
   http_routes/http_routes
   config/filter/filter
+  config/health_checker/health_checker
   common_messages/common_messages
   types/types

--- a/docs/root/api-v2/config/health_checker/health_checker.rst
+++ b/docs/root/api-v2/config/health_checker/health_checker.rst
@@ -1,0 +1,8 @@
+Health checkers
+===============
+
+.. toctree::
+  :glob:
+  :maxdepth: 1
+
+  */v2/*

--- a/docs/root/configuration/configuration.rst
+++ b/docs/root/configuration/configuration.rst
@@ -15,6 +15,7 @@ Configuration reference
   http_conn_man/http_conn_man
   http_filters/http_filters
   cluster_manager/cluster_manager
+  health_checkers/health_checkers
   access_log
   rate_limit
   runtime

--- a/docs/root/configuration/health_checkers/health_checkers.rst
+++ b/docs/root/configuration/health_checkers/health_checkers.rst
@@ -1,0 +1,9 @@
+.. _config_health_checkers:
+
+Health checkers
+===============
+
+.. toctree::
+  :maxdepth: 2
+
+  redis

--- a/docs/root/configuration/health_checkers/redis.rst
+++ b/docs/root/configuration/health_checkers/redis.rst
@@ -1,0 +1,14 @@
+.. _config_health_checkers_redis:
+
+Redis
+=====
+
+The Redis health checker is a custom health checker which checks Redis upstream hosts. It sends
+a Redis PING command and expect a PONG response. The upstream Redis server can respond with
+anything other than PONG to cause an immediate active health check failure. Optionally, Envoy can
+perform EXISTS on a user-specified key. If the key does not exist it is considered a passing healthcheck.
+This allows the user to mark a Redis instance for maintenance by setting the specified
+:ref:`key <envoy_api_field_config.health_checker.redis.v2.Redis.key>` to any value and waiting for
+traffic to drain.
+
+* :ref:`v2 API reference <envoy_api_msg_core.HealthCheck.CustomHealthCheck>`

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -19,6 +19,7 @@ Version history
   <envoy_api_field_core.HealthCheck.HttpHealthCheck.request_headers_to_add>` for HTTP health check.
 * health check: added support for EDS delivered :ref:`endpoint health status
   <envoy_api_field_endpoint.LbEndpoint.health_status>`.
+* health check: added support for :ref:`custom health check <envoy_api_field_core.HealthCheck.custom_health_check>`.
 * load balancing: added :ref:`weighted round robin
   <arch_overview_load_balancing_types_round_robin>` support. The round robin
   scheduler now respects endpoint weights and also has improved fidelity across

--- a/envoy/api/v2/core/health_check.proto
+++ b/envoy/api/v2/core/health_check.proto
@@ -116,7 +116,7 @@ message HealthCheck {
     string service_name = 1;
   }
 
-  // [#not-implemented-hide:] Custom health check.
+  // Custom health check.
   message CustomHealthCheck {
     // The registered name of the custom health check.
     string name = 1 [(validate.rules).string.min_bytes = 1];
@@ -141,7 +141,7 @@ message HealthCheck {
     // gRPC health check.
     GrpcHealthCheck grpc_health_check = 11;
 
-    // [#not-implemented-hide:] Custom health check.
+    // Custom health check.
     CustomHealthCheck custom_health_check = 13;
   }
 

--- a/envoy/config/health_checker/redis/v2/redis.proto
+++ b/envoy/config/health_checker/redis/v2/redis.proto
@@ -3,7 +3,6 @@ syntax = "proto3";
 package envoy.config.health_checker.redis.v2;
 option go_package = "v2";
 
-// [#not-implemented-hide:]
 // [#protodoc-title: Redis]
 // Redis :ref:`configuration overview <config_health_checker_redis>`.
 // Configuration for the Redis custom health checker.

--- a/envoy/config/health_checker/redis/v2/redis.proto
+++ b/envoy/config/health_checker/redis/v2/redis.proto
@@ -4,8 +4,8 @@ package envoy.config.health_checker.redis.v2;
 option go_package = "v2";
 
 // [#protodoc-title: Redis]
-// Redis :ref:`configuration overview <config_health_checker_redis>`.
-// Configuration for the Redis custom health checker.
+// Redis health checker :ref:`configuration overview <config_health_checkers_redis>`.
+
 message Redis {
   // If set, optionally perform ``EXISTS <key>`` instead of ``PING``. A return value
   // from Redis of 0 (does not exist) is considered a passing healthcheck. A return value other


### PR DESCRIPTION
This unhides custom health check and put it in the release note.

Ref: https://github.com/envoyproxy/envoy/pull/2993

Signed-off-by: Dhi Aurrahman <dio@rockybars.com>
