### PR TITLE
docs: Clarify verify_certificate_hash docs

### DIFF
--- a/envoy/api/v2/auth/cert.proto
+++ b/envoy/api/v2/auth/cert.proto
@@ -132,8 +132,15 @@ message CertificateValidationContext {
   // system CA locations.
   core.DataSource trusted_ca = 1;
 
-  // If specified, Envoy will verify (pin) the hex-encoded SHA-256 hash of
+  // If specified, Envoy will verify (pin) the hex-encoded SHA-256 fingerprint of
   // the presented certificate.
+  //
+  // For example, ``openssl`` can produce a SHA-256 fingerprint of an x509 certificate
+  // with the following command:
+  //
+  // .. code-block:: bash
+  //
+  //   $ openssl x509 -in path/to/client.crt -noout -fingerprint -sha256
   repeated string verify_certificate_hash = 2;
 
   // If specified, Envoy will verify (pin) base64-encoded SHA-256 hash of


### PR DESCRIPTION
This clarifies that `verify_certificate_hash` should be the _fingerprint_ of the cert, since "hash" is a little ambiguous and might lead to people (e.g. me) trying to hash the cert file itself.