### PR TITLE
health check: adding unhealthy interval overrides

### DIFF
--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -20,6 +20,10 @@ Version history
   <envoy_api_field_core.HealthCheck.HttpHealthCheck.request_headers_to_add>` for HTTP health check.
 * health check: added support for EDS delivered :ref:`endpoint health status
   <envoy_api_field_endpoint.LbEndpoint.health_status>`.
+* health check: added interval overrides for health state transitions from :ref:`healthy to unhealthy
+  <envoy_api_field_core.HealthCheck.unhealthy_edge_interval>`, :ref:`unhealthy to healthy
+  <envoy_api_field_core.HealthCheck.healthy_edge_interval>` and for subsequent checks on
+  :ref:`unhealthy hosts <envoy_api_field_core.HealthCheck.unhealthy_interval>`.
 * load balancing: added :ref:`weighted round robin
   <arch_overview_load_balancing_types_round_robin>` support. The round robin
   scheduler now respects endpoint weights and also has improved fidelity across

--- a/envoy/api/v2/core/health_check.proto
+++ b/envoy/api/v2/core/health_check.proto
@@ -149,10 +149,33 @@ message HealthCheck {
   // never had traffic routed to it. This lower interval allows cluster information to be kept up to
   // date, without sending a potentially large amount of active health checking traffic for no
   // reason. Once a cluster has been used for traffic routing, Envoy will shift back to using the
-  // standard health check interval that is defined.
+  // standard health check interval that is defined. Note that this interval takes precedence over
+  // any other.
   //
   // The default value for "no traffic interval" is 60 seconds.
   google.protobuf.Duration no_traffic_interval = 12;
+
+  // The "unhealthy interval" is a health check interval that is used for hosts that are marked as
+  // unhealthy. As soon as the host is marked as healthy, Envoy will shift back to using the
+  // standard health check interval that is defined.
+  //
+  // The default value for "unhealthy interval" is the same as "interval".
+  google.protobuf.Duration unhealthy_interval = 14;
+
+  // The "unhealthy edge interval" is a special health check interval that is used for the first
+  // health check right after a host is marked as unhealthy. For subsequent health checks
+  // Envoy will shift back to using either "unhealthy interval" if present or the standard health
+  // check interval that is defined.
+  //
+  // The default value for "unhealthy edge interval" is the same as "unhealthy interval".
+  google.protobuf.Duration unhealthy_edge_interval = 15;
+
+  // The "healthy edge interval" is a special health check interval that is used for the first
+  // health check right after a host is marked as healthy. For subsequent health checks
+  // Envoy will shift back to using the standard health check interval that is defined.
+  //
+  // The default value for "healthy edge interval" is the same as the default interval.
+  google.protobuf.Duration healthy_edge_interval = 16;
 }
 
 // Endpoint health status.


### PR DESCRIPTION
Three new settings are added to override health check intervals for hosts that are unhealthy or in transitioning state. This is necessary to achieve feature parity with HAProxy's [`fastinter` and `downinter`](https://www.haproxy.com/documentation/aloha/7-0/traffic-management/lb-layer7/health-checks/#health-check-parameters), thus trivializing the transition from the latter to Envoy.

Envoy PR: https://github.com/envoyproxy/envoy/pull/3048

This is the data plane side of the implementation for the issue https://github.com/envoyproxy/envoy/issues/2499.