### PR TITLE
access log: add header based filter

### DIFF
--- a/envoy/config/filter/accesslog/v2/BUILD
+++ b/envoy/config/filter/accesslog/v2/BUILD
@@ -16,6 +16,7 @@ api_proto_library(
         "//envoy/api/v2/core:base",
         "//envoy/api/v2/core:grpc_service",
         "//envoy/type:percent",
+        "//envoy/type:range",
     ],
 )
 
@@ -27,5 +28,6 @@ api_go_proto_library(
         "//envoy/api/v2/core:base_go_proto",
         "//envoy/api/v2/core:grpc_service_go_proto",
         "//envoy/type:percent_go_proto",
+        "//envoy/type:range_go_proto",
     ],
 )

--- a/envoy/config/filter/accesslog/v2/BUILD
+++ b/envoy/config/filter/accesslog/v2/BUILD
@@ -15,8 +15,8 @@ api_proto_library(
         "//envoy/api/v2/core:address",
         "//envoy/api/v2/core:base",
         "//envoy/api/v2/core:grpc_service",
+        "//envoy/api/v2/route",
         "//envoy/type:percent",
-        "//envoy/type:range",
     ],
 )
 
@@ -27,7 +27,7 @@ api_go_proto_library(
         "//envoy/api/v2/core:address_go_proto",
         "//envoy/api/v2/core:base_go_proto",
         "//envoy/api/v2/core:grpc_service_go_proto",
+        "//envoy/api/v2/route:route_go_proto",
         "//envoy/type:percent_go_proto",
-        "//envoy/type:range_go_proto",
     ],
 )

--- a/envoy/config/filter/accesslog/v2/accesslog.proto
+++ b/envoy/config/filter/accesslog/v2/accesslog.proto
@@ -5,8 +5,8 @@ option go_package = "v2";
 
 import "envoy/api/v2/core/address.proto";
 import "envoy/api/v2/core/base.proto";
+import "envoy/api/v2/route/route.proto";
 import "envoy/type/percent.proto";
-import "envoy/type/range.proto";
 
 import "google/protobuf/duration.proto";
 import "google/protobuf/struct.proto";
@@ -332,6 +332,9 @@ message AccessLogFilter {
 
     // Or filter.
     OrFilter or_filter = 7;
+
+    // [#not-implemented-hide:] Header filter.
+    HeaderFilter header_filter = 8;
   }
 }
 
@@ -416,41 +419,10 @@ message OrFilter {
 }
 
 // [#not-implemented-hide:] Filters requests based on the presence or value of a request header.
-message HeaderValueFilter {
-  // Specifies the name of the request header to filter on.
-  string name = 1 [(validate.rules).string.min_bytes = 1];
-
-  // Specifies how the header match will be performed to filter the request.
-  // If absent, any request with the header present will match, regardless of the header's value.
-  oneof header_match_specifier {
-    // Filter will only allow requests where the header's value equals `exact_match`.
-    string exact_match = 2;
-
-    // A regular expression rule which the *entire* header's value must match.
-    // Filter will not allow requests where only a subsequence of the header's value
-    // matches the regex.
-    // The regex grammar used in the value field is defined
-    // `here <http://en.cppreference.com/w/cpp/regex/ecmascript>`_.
-    //
-    // Examples:
-    //
-    // * The regex *\d{3}* matches the value *123*
-    // * The regex *\d{3}* does not match the value *1234*
-    // * The regex *\d{3}* does not match the value *123.456*
-    string regex_match = 3;
-
-    // The rule will match if the header's value is within the specified range.
-    // The *entire* request header value must represent an integer in base 10 notation: consisting
-    // of an optional plus or minus sign followed by a sequence of digits. The rule will not match
-    // if the header value does not represent an integer. Match will fail for empty values, floating
-    // point numbers or if only a subsequence of the header value is an integer.
-    //
-    // Examples:
-    //
-    // * For range [-10,0), route will match for header value -1, but not for 0, "somestring", 10.9,
-    //   "-1somestring"
-    envoy.type.Int64Range range_match = 4;
-  }
+message HeaderFilter {
+  // Only requests with a header which matches the specified HeaderMatcher will pass the filter
+  // check.
+  envoy.api.v2.route.HeaderMatcher header = 1 [(validate.rules).message.required = true];
 }
 
 // Custom configuration for an AccessLog that writes log entries directly to a file.

--- a/envoy/config/filter/accesslog/v2/accesslog.proto
+++ b/envoy/config/filter/accesslog/v2/accesslog.proto
@@ -6,6 +6,7 @@ option go_package = "v2";
 import "envoy/api/v2/core/address.proto";
 import "envoy/api/v2/core/base.proto";
 import "envoy/type/percent.proto";
+import "envoy/type/range.proto";
 
 import "google/protobuf/duration.proto";
 import "google/protobuf/struct.proto";
@@ -412,6 +413,44 @@ message AndFilter {
 // filter returns true immediately.
 message OrFilter {
   repeated AccessLogFilter filters = 2 [(validate.rules).repeated .min_items = 2];
+}
+
+// [#not-implemented-hide:] Filters requests based on the presence or value of a request header.
+message HeaderValueFilter {
+  // Specifies the name of the request header to filter on.
+  string name = 1 [(validate.rules).string.min_bytes = 1];
+
+  // Specifies how the header match will be performed to filter the request.
+  // If absent, any request with the header present will match, regardless of the header's value.
+  oneof header_match_specifier {
+    // Filter will only allow requests where the header's value equals `exact_match`.
+    string exact_match = 2;
+
+    // A regular expression rule which the *entire* header's value must match.
+    // Filter will not allow requests where only a subsequence of the header's value
+    // matches the regex.
+    // The regex grammar used in the value field is defined
+    // `here <http://en.cppreference.com/w/cpp/regex/ecmascript>`_.
+    //
+    // Examples:
+    //
+    // * The regex *\d{3}* matches the value *123*
+    // * The regex *\d{3}* does not match the value *1234*
+    // * The regex *\d{3}* does not match the value *123.456*
+    string regex_match = 3;
+
+    // The rule will match if the header's value is within the specified range.
+    // The *entire* request header value must represent an integer in base 10 notation: consisting
+    // of an optional plus or minus sign followed by a sequence of digits. The rule will not match
+    // if the header value does not represent an integer. Match will fail for empty values, floating
+    // point numbers or if only a subsequence of the header value is an integer.
+    //
+    // Examples:
+    //
+    // * For range [-10,0), route will match for header value -1, but not for 0, "somestring", 10.9,
+    //   "-1somestring"
+    envoy.type.Int64Range range_match = 4;
+  }
 }
 
 // Custom configuration for an AccessLog that writes log entries directly to a file.


### PR DESCRIPTION
define an access log filter to filter requests based on the value of a specified header.

This is the initial data plane api change for the issue envoyproxy/envoy#2544.

Signed-off-by: Kevin Chan <kevintchan@yahoo.com>