### PR TITLE
Add health check filter header match

### DIFF
--- a/envoy/config/filter/http/health_check/v2/BUILD
+++ b/envoy/config/filter/http/health_check/v2/BUILD
@@ -6,6 +6,7 @@ api_proto_library(
     name = "health_check",
     srcs = ["health_check.proto"],
     deps = [
+        "//envoy/api/v2/route",
         "//envoy/type:percent",
     ],
 )
@@ -14,6 +15,7 @@ api_go_proto_library(
     name = "health_check",
     proto = ":health_check",
     deps = [
+        "//envoy/api/v2/route:route_go_proto",
         "//envoy/type:percent_go_proto",
     ],
 )

--- a/envoy/config/filter/http/health_check/v2/health_check.proto
+++ b/envoy/config/filter/http/health_check/v2/health_check.proto
@@ -35,6 +35,7 @@ message HealthCheck {
   // [#not-implemented-hide:]
   // Specifies a set of health check request headers to match on. The health check filter will
   // check a request’s headers against all the specified headers. A request will be considered a
-  // health check request if all headers are present.
+  // health check request if all headers are present. Notice that if specificed, the ``:path``
+  // header must also match the value specified in the ``endpoint`` field.
   repeated envoy.api.v2.route.HeaderMatcher headers = 5;
 }

--- a/envoy/config/filter/http/health_check/v2/health_check.proto
+++ b/envoy/config/filter/http/health_check/v2/health_check.proto
@@ -21,7 +21,7 @@ message HealthCheck {
 
   // Specifies the incoming HTTP endpoint that should be considered the
   // health check endpoint. For example */healthcheck*.
-  string endpoint = 2 [(validate.rules).string.min_bytes = 1];
+  string endpoint = 2 [deprecated = true];
 
   // If operating in pass through mode, the amount of time in milliseconds
   // that the filter should cache the upstream response.
@@ -34,8 +34,9 @@ message HealthCheck {
 
   // [#not-implemented-hide:]
   // Specifies a set of health check request headers to match on. The health check filter will
-  // check a request’s headers against all the specified headers. A request will be considered a
-  // health check request if all headers are present. Notice that if specificed, the ``:path``
-  // header must also match the value specified in the ``endpoint`` field.
+  // check a request’s headers against all the specified headers. To specify the
+  // health check endpoint, set the ``:path`` header to match on. Notice that if the
+  // :ref:`endpoint <envoy_api_field_config.filter.http.health_check.v2.HealthCheck.endpoint>`
+  // field is set, it will overwrite any ``:path`` header to match.
   repeated envoy.api.v2.route.HeaderMatcher headers = 5;
 }

--- a/envoy/config/filter/http/health_check/v2/health_check.proto
+++ b/envoy/config/filter/http/health_check/v2/health_check.proto
@@ -21,7 +21,7 @@ message HealthCheck {
 
   // Specifies the incoming HTTP endpoint that should be considered the
   // health check endpoint. For example */healthcheck*.
-  string endpoint = 2 [deprecated = true];
+  string endpoint = 2 [(validate.rules).string.min_bytes = 1, deprecated = true];
 
   // If operating in pass through mode, the amount of time in milliseconds
   // that the filter should cache the upstream response.
@@ -35,7 +35,7 @@ message HealthCheck {
   // [#not-implemented-hide:]
   // Specifies a set of health check request headers to match on. The health check filter will
   // check a request’s headers against all the specified headers. To specify the health check
-  // endpoint, set the ``:path`` header to match on. Notice that if the
+  // endpoint, set the ``:path`` header to match on. Note that if the
   // :ref:`endpoint <envoy_api_field_config.filter.http.health_check.v2.HealthCheck.endpoint>`
   // field is set, it will overwrite any ``:path`` header to match.
   repeated envoy.api.v2.route.HeaderMatcher headers = 5;

--- a/envoy/config/filter/http/health_check/v2/health_check.proto
+++ b/envoy/config/filter/http/health_check/v2/health_check.proto
@@ -6,6 +6,7 @@ option go_package = "v2";
 import "google/protobuf/duration.proto";
 import "google/protobuf/wrappers.proto";
 
+import "envoy/api/v2/route/route.proto";
 import "envoy/type/percent.proto";
 
 import "validate/validate.proto";
@@ -30,4 +31,10 @@ message HealthCheck {
   // names and the minimum percentage of servers in each of those clusters that
   // must be healthy in order for the filter to return a 200.
   map<string, envoy.type.Percent> cluster_min_healthy_percentages = 4;
+
+  // [#not-implemented-hide:]
+  // Specifies a set of health check request headers to match on. The health check filter will
+  // check a request’s headers against all the specified headers. A request will be considered a
+  // health check request if all headers are present.
+  repeated envoy.api.v2.route.HeaderMatcher headers = 5;
 }

--- a/envoy/config/filter/http/health_check/v2/health_check.proto
+++ b/envoy/config/filter/http/health_check/v2/health_check.proto
@@ -34,8 +34,8 @@ message HealthCheck {
 
   // [#not-implemented-hide:]
   // Specifies a set of health check request headers to match on. The health check filter will
-  // check a request’s headers against all the specified headers. To specify the
-  // health check endpoint, set the ``:path`` header to match on. Notice that if the
+  // check a request’s headers against all the specified headers. To specify the health check
+  // endpoint, set the ``:path`` header to match on. Notice that if the
   // :ref:`endpoint <envoy_api_field_config.filter.http.health_check.v2.HealthCheck.endpoint>`
   // field is set, it will overwrite any ``:path`` header to match.
   repeated envoy.api.v2.route.HeaderMatcher headers = 5;


### PR DESCRIPTION
Add a header match field to the Http health check filter. This allows filtering health check requests not only on endpoint, but also request headers. 

We need this internally for health checking. Does this sound like a generally useful feature to add?
