### PR TITLE
ci: Add sync workflow

### DIFF
--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -1,0 +1,38 @@
+name: Sync Envoy
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  sync:
+    runs-on: ubuntu-20.04
+    permissions:
+      contents: write
+    if: |
+      ${{
+          !contains(github.actor, '[bot]')
+          || github.actor == 'sync-envoy[bot]'
+      }}
+    steps:
+    # Checkout the repo at provided commit
+    - name: 'Checkout Repository'
+      uses: actions/checkout@v3
+
+    # Checkout the Envoy repo at latest commit
+    - name: 'Checkout Repository'
+      uses: actions/checkout@v3
+      with:
+        repository: envoyproxy/envoy
+        fetch-depth: 0
+        path: upstream
+
+    - run: mv upstream ../envoy
+    - run: ci/mirror.sh
+      working-directory: ../envoy

--- a/ci/mirror.sh
+++ b/ci/mirror.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+set -e
+
+CHECKOUT_DIR=../data-plane-api
+API_MAIN_BRANCH="main"
+
+# Determine last envoyproxy/envoy SHA in envoyproxy/data-plane-api
+MIRROR_MSG="Mirrored from https://github.com/envoyproxy/envoy"
+LAST_ENVOY_SHA=$(git -C "$CHECKOUT_DIR" log --grep="$MIRROR_MSG" -n 1 | grep "$MIRROR_MSG" | \
+  tail -n 1 | sed -e "s#.*$MIRROR_MSG @ ##")
+
+echo "Last mirrored envoyproxy/envoy SHA is $LAST_ENVOY_SHA"
+
+# Compute SHA sequence to replay in envoyproxy/data-plane-api
+SHAS=$(git rev-list --reverse "$LAST_ENVOY_SHA"..HEAD api/)
+
+# For each SHA, hard reset, rsync api/ and generate commit in
+# envoyproxy/data-plane-api
+API_WORKING_DIR="../envoy-api-mirror"
+git worktree add "$API_WORKING_DIR"
+for sha in $SHAS; do
+    echo "Adding commit ${sha}"
+    git -C "$API_WORKING_DIR" reset --hard "$sha"
+    COMMIT_MSG=$(git -C "$API_WORKING_DIR" log --format=%B -n 1)
+    QUALIFIED_COMMIT_MSG=$(echo -e "$COMMIT_MSG\n\n$MIRROR_MSG @ $sha")
+    rsync -acv --delete --exclude "ci/" --exclude ".*" --exclude LICENSE \
+          "$API_WORKING_DIR"/api/ "$CHECKOUT_DIR"/
+    git -C "$CHECKOUT_DIR" add .
+    git -C "$CHECKOUT_DIR" commit -m "$QUALIFIED_COMMIT_MSG"
+done
+
+if [[ -n "$SHAS" ]]; then
+    echo "Pushing..."
+    git -C "$CHECKOUT_DIR" push origin "${API_MAIN_BRANCH}"
+else
+    echo "Nothing to push"
+fi
+echo "Done"


### PR DESCRIPTION
Currently Envoy CI uses an SSH key with all powers to sync this repo by pushing to it

This is not optimally secure, and furthermore this pattern regularly causes Envoy CI to flake racing to checkout downstream repos.

I have created an app with just wf trigger permissions and added it to this repo

This PR adds a workflow that can be triggered to sync Envoy by pulling from it